### PR TITLE
update codespell with fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+# See https://pre-commit.ci/#configuration
 
+ci:
+  autofix_prs: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.4.0"
@@ -30,7 +33,7 @@ repos:
         args: [--fix]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.2"
+    rev: "v2.2.4"
     hooks:
     - id: codespell
       types_or: [python, markdown, rst]

--- a/src/geovista/__init__.py
+++ b/src/geovista/__init__.py
@@ -9,7 +9,7 @@ Provides:
      geospatial data to native geo-located PyVista mesh instances
   2. Compliments PyVista with cartographic features for processing, projecting
      and rendering geo-located meshes
-  3. Support for interactive 3D visulization of geo-located meshes
+  3. Support for interactive 3D visualization of geo-located meshes
   4. Coordinate Reference System (CRS) support, with an awareness of Cartopy
      CRSs through the commonality of the Python interface to PROJ (PyPROJ)
      package


### PR DESCRIPTION
## 🚀 Pull Request

### Description
The update of `codespell` from 2.2.2 -> 2.2.4 detects a new typo in a doc-string.

Also explicitly disabled `pre-commit.ci` auto-fixing, instead forcing the user to understand the nature of the `pre-commit.ci` failure. 

To accept auto-fix changes, simply add `pre-commit.ci autofix` to a comment on the failing PR.

Reference: https://pre-commit.ci/#configuration

---
