### PR TITLE
fix flake8-bugbear B028

### DIFF
--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -714,7 +714,7 @@ class Transform:
                     f"Masked connectivity defines {n_invalid:,} face{plural} "
                     "with no vertices."
                 )
-                warnings.warn(wmsg)
+                warnings.warn(wmsg, stacklevel=2)
                 n_vertices = n_vertices[valid_faces_mask]
                 connectivity = connectivity[valid_faces_mask]
             faces = ma.hstack([n_vertices.reshape(-1, 1), connectivity]).ravel()

--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -551,7 +551,7 @@ def cut_along_meridian(
                     f"Unable to remesh {n_cells} cell{plural}. Removing the "
                     f"following mesh cell-id{plural} [{naughty}]."
                 )
-                warnings.warn(wmsg)
+                warnings.warn(wmsg, stacklevel=2)
                 remeshed_ids = np.hstack([remeshed_ids, bad_cids])
 
     if meshes:

--- a/src/geovista/geodesic.py
+++ b/src/geovista/geodesic.py
@@ -177,7 +177,7 @@ class BBox:
                     "however the first and last values are not close enough to specify "
                     "a closed geometry - ignoring last value."
                 )
-                warnings.warn(wmsg)
+                warnings.warn(wmsg, stacklevel=2)
                 lons, lats = lons[:-1], lats[:-1]
 
         self.lons = lons

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -98,7 +98,7 @@ class GeoPlotterBase:
                     f"{klass} received an unexpected argument. "
                     "Assuming 'crs' keyword argument instead..."
                 )
-                warn(wmsg)
+                warn(wmsg, stacklevel=2)
                 kwargs["crs"] = args[0]
                 args = ()
             else:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Auto-discovered by `ruff`:

```
B028: No explicit stacklevel argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
```

Reference: https://github.com/PyCQA/flake8-bugbear

---
