### PR TITLE
reset default zlevel-factor

### DIFF
--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -94,7 +94,7 @@ WRAP_ATOL: float = 1e-8
 WRAP_RTOL: float = 1e-5
 
 #: Proportional multiplier for z-axis levels/offsets.
-ZLEVEL_FACTOR: float = 1e-4
+ZLEVEL_FACTOR: float = 1e-3
 
 
 def active_kernel() -> bool:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Increase the default `ZLEVEL_FACTOR` as `geovista.examples.from_unstructured__tri` is showing base-layer bleed-thru... although this might be the symptom of another issue which is currently being investigated i.e., resizing of base-layer meshes.

e.g., `ZFACTOR_DEFAULT = 1e-4` gives the following...

![image](https://github.com/bjlittle/geovista/assets/2051656/ec07333d-eac3-45eb-aabf-6cfb1a2fd7af)


The sane default of `1e-3` is currently working, so let's roll with that for now.

---
