### PR TITLE
disable bridge mesh cleaning by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ mesh = gv.Transform.from_unstructured(
     connectivity=sample.connectivity,
     data=sample.face,
     name="face",
-    clean=False,
 )
 
 # Warp the mesh nodes by the bathymetry.

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -37,7 +37,7 @@ Shape = tuple[int]
 CRSLike = Union[int, str, dict, CRS]
 
 #: Default mesh cleaning.
-DEFAULT_CLEAN: bool = True
+DEFAULT_CLEAN: bool = False
 
 #: Default array name for data on the mesh points/vertices/nodes.
 DEFAULT_NAME_POINTS: str = "point_data"
@@ -392,9 +392,10 @@ class Transform:
         zlevel : int, default=0
             The z-axis level/offset of the mesh, giving a computed `radius`
             of ``radius + zlevel * zfactor``.
-        clean : bool, default=True
+        clean : bool, optional
             Specify whether to merge duplicate points, remove unused points,
-            and/or remove degenerate cells in the resultant mesh.
+            and/or remove degenerate cells in the resultant mesh. Defaults to
+            :data:`DEFAULT_CLEAN`.
 
         Returns
         -------
@@ -475,9 +476,10 @@ class Transform:
         zlevel : int, default=0
             The z-axis level/offset of the mesh, giving a computed `radius`
             of ``radius + zlevel * zfactor``.
-        clean : bool, default=True
+        clean : bool, optional
             Specify whether to merge duplicate points, remove unused points,
-            and/or remove degenerate cells in the resultant mesh.
+            and/or remove degenerate cells in the resultant mesh. Defaults to
+            :data:`DEFAULT_CLEAN`.
 
         Returns
         -------
@@ -593,9 +595,10 @@ class Transform:
         zlevel : int, default=0
             The z-axis level/offset of the mesh, giving a computed `radius`
             of ``radius + zlevel * zfactor``.
-        clean : bool, default=True
+        clean : bool, optional
             Specify whether to merge duplicate points, remove unused points,
-            and/or remove degenerate cells in the resultant mesh.
+            and/or remove degenerate cells in the resultant mesh. Defaults to
+            :data:`DEFAULT_CLEAN`.
 
         Returns
         -------
@@ -821,9 +824,10 @@ class Transform:
         zlevel : int, default=0
             The z-axis level/offset of the mesh, giving a computed `radius`
             of ``radius + zlevel * zfactor``.
-        clean : bool, default=True
+        clean : bool, optional
             Specify whether to merge duplicate points, remove unused points,
-            and/or remove degenerate cells in the resultant mesh.
+            and/or remove degenerate cells in the resultant mesh. Defaults to
+            :data:`DEFAULT_CLEAN`.
 
         Notes
         -----

--- a/src/geovista/examples/from_1d__oisst_eqc.py
+++ b/src/geovista/examples/from_1d__oisst_eqc.py
@@ -31,7 +31,7 @@ def main() -> None:
     sample = oisst_avhrr_sst()
 
     # create the mesh from the sample data
-    mesh = gv.Transform.from_1d(sample.lons, sample.lats, data=sample.data, clean=False)
+    mesh = gv.Transform.from_1d(sample.lons, sample.lats, data=sample.data)
 
     # provide mesh diagnostics via logging
     gv.logger.info("%s", mesh)

--- a/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
+++ b/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
@@ -32,7 +32,7 @@ def main() -> None:
 
     # create the mesh from the synthetic data
     name = "Synthetic Cells"
-    mesh = gv.Transform.from_1d(lons, lats, data=data, name=name, clean=False)
+    mesh = gv.Transform.from_1d(lons, lats, data=data, name=name)
 
     # provide mesh diagnostics via logging
     gv.logger.info("%s", mesh)

--- a/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
+++ b/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
@@ -32,7 +32,7 @@ def main() -> None:
 
     # create the mesh from the synthetic data
     name = "Synthetic Points"
-    mesh = gv.Transform.from_1d(lons, lats, data=data, name=name, clean=False)
+    mesh = gv.Transform.from_1d(lons, lats, data=data, name=name)
 
     # provide mesh diagnostics via logging
     gv.logger.info("%s", mesh)

--- a/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
+++ b/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
@@ -33,7 +33,7 @@ def main() -> None:
 
     # create the mesh from the synthetic data
     name = "Synthetic Cells"
-    mesh = gv.Transform.from_2d(mlons, mlats, data=data, name=name, clean=False)
+    mesh = gv.Transform.from_2d(mlons, mlats, data=data, name=name)
 
     # provide mesh diagnostics via logging
     gv.logger.info("%s", mesh)

--- a/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
+++ b/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
@@ -33,7 +33,7 @@ def main() -> None:
 
     # create the mesh from the synthetic data
     name = "Synthetic Points"
-    mesh = gv.Transform.from_2d(mlons, mlats, data=data, name=name, clean=False)
+    mesh = gv.Transform.from_2d(mlons, mlats, data=data, name=name)
 
     # provide mesh diagnostics via logging
     gv.logger.info("%s", mesh)

--- a/src/geovista/examples/from_unstructured__fesom_fouc.py
+++ b/src/geovista/examples/from_unstructured__fesom_fouc.py
@@ -31,7 +31,11 @@ def main() -> None:
 
     # create the mesh from the sample data
     mesh = gv.Transform.from_unstructured(
-        sample.lons, sample.lats, connectivity=sample.connectivity, data=sample.data
+        sample.lons,
+        sample.lats,
+        connectivity=sample.connectivity,
+        data=sample.data,
+        clean=True,
     )
 
     # provide mesh diagnostics via logging

--- a/src/geovista/examples/from_unstructured__fvcom.py
+++ b/src/geovista/examples/from_unstructured__fvcom.py
@@ -36,7 +36,6 @@ def main() -> None:
         connectivity=sample.connectivity,
         data=sample.face,
         name="face",
-        clean=False,
     )
 
     # provide mesh diagnostics via logging


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

There is a significant performance gain to be had by large meshes by not cleaning them by default on creation within the `geovista.bridge`. This PR makes this an opt-in option rather than an opt-out.

---
