### PR TITLE
resolve explicit dependencies with conda-lock

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,32 +7,32 @@ requires =
 [testenv:py{39,310,311}-lock]
 allowlist_externals =
     cp
+changedir =
+    {env:LOCK}
 conda_channels =
     conda-forge
 conda_create_args =
     --override-channels
 conda_deps =
-    pip
+    conda-lock
     mamba
+    pip
 description =
     Create explicit environment specification conda lock files for geovista dependencies.
 platform =
     linux
 setenv =
-    LOCK = {toxinidir}{/}requirements{/}locks{/}{envname}-linux-64.txt
+    LOCK = {toxinidir}{/}requirements{/}locks
     WORK = {envtmpdir}{/}geovista.yml
     YAML = {toxinidir}{/}requirements{/}geovista.yml
 skip_install =
     true
 commands =
-    # inject python version pin
+    # inject python version pin to yaml
     cp {env:YAML} {env:WORK}
     python -c 'from sys import version_info as v; open("{env:WORK}", "a").write(f"\n  - python =\{v.major\}.\{v.minor\}\n")'
-    # opt-out from conda-lock as require Core Dependency Tree (CDT) for OpenGL
-    mamba env remove --name {envname}
-    mamba env create --name {envname} --file {env:WORK}
-    # tox doesn't support shell redirection
-    python -c 'import subprocess; subprocess.run(["mamba", "list", "-n={envname}", "--explicit"], stdout=open("{env:LOCK}", "w"))'
+    # resolve the dependencies
+    conda-lock --mamba --channel conda-forge --kind explicit --file {env:WORK} --platform linux-64 --filename-template "{envname}-\{platform\}.txt"
 
 
 [testenv:py{39,310,311}-env]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Given that `vtk` is now unpinned (see #254), this PR reverts #230 which dropped the use of `conda-lock` to resolve the explicit dependencies.

The issue of missing OpenGL CDT dependencies appears to be caused by the pinning of `vtk` within `geovista`, and not `conda-lock`.

---
