### PR TITLE
avoid mpl 3.7 get_cmap deprecation warning

### DIFF
--- a/src/geovista/examples/from_unstructured__icon.py
+++ b/src/geovista/examples/from_unstructured__icon.py
@@ -7,7 +7,7 @@ Notes
 
 """
 
-import matplotlib.pyplot as plt
+import matplotlib as mpl
 
 import geovista as gv
 from geovista.pantry import icon_soil
@@ -39,7 +39,7 @@ def main() -> None:
     # plot the mesh
     plotter = gv.GeoPlotter()
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
-    cmap = plt.cm.get_cmap("cet_CET_L17", lut=9)
+    cmap = mpl.colormaps.get_cmap("cet_CET_L17").resampled(lutsize=9)
     plotter.add_mesh(mesh, cmap=cmap, show_edges=True, scalar_bar_args=sargs)
     plotter.add_coastlines()
     plotter.add_axes()

--- a/src/geovista/examples/from_unstructured__icon_eqc.py
+++ b/src/geovista/examples/from_unstructured__icon_eqc.py
@@ -7,7 +7,7 @@ Notes
 
 """
 
-import matplotlib.pyplot as plt
+import matplotlib as mpl
 
 import geovista as gv
 from geovista.pantry import icon_soil
@@ -40,7 +40,7 @@ def main() -> None:
     # plot the mesh
     plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"))
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
-    cmap = plt.cm.get_cmap("cet_CET_L17", lut=9)
+    cmap = mpl.colormaps.get_cmap("cet_CET_L17").resampled(lutsize=9)
     plotter.add_mesh(mesh, cmap=cmap, show_edges=True, scalar_bar_args=sargs)
     plotter.add_coastlines()
     plotter.add_axes()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Avoids the following `matplotlib` deprecation warning:

```
MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
```

---
