### PR TITLE
codecov ignore cli

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ coverage:
     patch: off
 
 ignore:
+  - "**/cli.py"
   - "**/geoplotter.py"
   - "**/pantry.py"
   - "**/registry.txt"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

There is no coverage reported for `geovista.cli` as the approach for automated testing a `click` CLI is unclear (to me).

This ignore makes it explicit that there is no intent to test the CLI atm.

---
