### PR TITLE
add graticule support

### DIFF
--- a/src/geovista/__init__.py
+++ b/src/geovista/__init__.py
@@ -15,6 +15,8 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
+
 import logging
 
 from .bridge import Transform  # noqa: F401

--- a/src/geovista/__main__.py
+++ b/src/geovista/__main__.py
@@ -1,4 +1,6 @@
 """Entry-point for geovista command line interface (CLI)."""
+from __future__ import annotations
+
 from .cli import main
 
 main()

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -404,11 +404,11 @@ def from_cartesian(
 
     # XXX: manage pole longitudes. an alternative future scheme could be more
     # generic and inclusive, but this approach tackles the main use case for now
-    # TBD: refactor this into a separate function
+    # TODO: refactor this into a separate function
     pole_pids = np.where(np.isclose(np.abs(lats), 90))[0]
     if pole_pids.size:
         # enforce a common longitude for pole singularities
-        # TBD: review this strategy
+        # TODO: review this strategy
         lons[pole_pids] = 0
 
         if (
@@ -466,7 +466,7 @@ def from_cartesian(
             seam_mask = np.isclose(np.abs(seam_lons), 180)
             lons[seam_ids[seam_mask]] = 180
         elif mesh.n_lines:
-            # TBD: unify closed interval strategies for lines and cells
+            # TODO: unify closed interval strategies for lines and cells
             poi_mask = np.isclose(np.abs(lons), 180)
 
             if np.any(poi_mask):

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -408,6 +408,7 @@ def from_cartesian(
     pole_pids = np.where(np.isclose(np.abs(lats), 90))[0]
     if pole_pids.size:
         # enforce a common longitude for pole singularities
+        # TBD: review this strategy
         lons[pole_pids] = 0
 
         if (

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -407,49 +407,56 @@ def from_cartesian(
     # TBD: refactor this into a separate function
     pole_pids = np.where(np.isclose(np.abs(lats), 90))[0]
     if pole_pids.size:
-        # enforce a common longitude for pole singularity mesh points
+        # enforce a common longitude for pole singularities
         lons[pole_pids] = 0
 
-        # unfold pole quad-cells
-        pole_submesh = mesh.extract_points(pole_pids)
-        pole_pids = set(pole_pids)
-        # get the indices (cids) of polar participating mesh cells
-        pole_cids = np.unique(pole_submesh["vtkOriginalCellIds"])
-        for cid in pole_cids:
-            # get the indices (pids) of the polar cell points
-            # XXX: pyvista 0.38.0: cell_point_ids(cid) -> get_cell(cid).point_ids
-            cell_pids = np.array(mesh.get_cell(cid).point_ids)
-            # TODO: only dealing with quad-cells atm
-            if len(cell_pids) == 4:
-                # identify the pids of the cell on the pole
-                cell_pole_pids = pole_pids.intersection(cell_pids)
-                # criterion of exactly two points from the quad-cell
-                # at the pole to unfold the polar points longitudes
-                if len(cell_pole_pids) == 2:
-                    # compute the relative offset of the polar points
-                    # within the polar cell connectivity
-                    offset = sorted(
-                        [np.where(cell_pids == pid)[0][0] for pid in cell_pole_pids]
-                    )
-                    if offset == [0, 1]:
-                        lhs = cell_pids[offset]
-                        rhs = cell_pids[[3, 2]]
-                    elif offset == [1, 2]:
-                        lhs = cell_pids[offset]
-                        rhs = cell_pids[[0, 3]]
-                    elif offset == [2, 3]:
-                        lhs = cell_pids[offset]
-                        rhs = cell_pids[[1, 0]]
-                    elif offset == [0, 3]:
-                        lhs = cell_pids[offset]
-                        rhs = cell_pids[[1, 2]]
-                    else:
-                        emsg = (
-                            "Failed to unfold a mesh polar quad-cell. Invalid "
-                            "polar points connectivity detected."
+        if (
+            mesh.n_points
+            and {0, mesh.n_points - 1} == set(pole_pids)
+            and np.unique(lons[1:-1]).size == 1
+        ):
+            # unfold polar end-points of a meridian i.e., a line of constant longitude
+            lons[0] = lons[-1] = lons[1]
+        else:
+            pole_submesh = mesh.extract_points(pole_pids)
+            pole_pids = set(pole_pids)
+            # get the cids (cell-indices) of mesh cells with polar vertices
+            pole_cids = np.unique(pole_submesh["vtkOriginalCellIds"])
+            for cid in pole_cids:
+                # get the pids (point-indices) of the polar cell points
+                # XXX: pyvista 0.38.0: cell_point_ids(cid) -> get_cell(cid).point_ids
+                cell_pids = np.array(mesh.get_cell(cid).point_ids)
+                # unfold polar quad-cells
+                if len(cell_pids) == 4:
+                    # identify the pids of the cell on the pole
+                    cell_pole_pids = pole_pids.intersection(cell_pids)
+                    # criterion of exactly two points from the quad-cell
+                    # at the pole to unfold the polar points longitudes
+                    if len(cell_pole_pids) == 2:
+                        # compute the relative offset of the polar points
+                        # within the polar cell connectivity
+                        offset = sorted(
+                            [np.where(cell_pids == pid)[0][0] for pid in cell_pole_pids]
                         )
-                        raise ValueError(emsg)
-                    lons[lhs] = lons[rhs]
+                        if offset == [0, 1]:
+                            lhs = cell_pids[offset]
+                            rhs = cell_pids[[3, 2]]
+                        elif offset == [1, 2]:
+                            lhs = cell_pids[offset]
+                            rhs = cell_pids[[0, 3]]
+                        elif offset == [2, 3]:
+                            lhs = cell_pids[offset]
+                            rhs = cell_pids[[1, 0]]
+                        elif offset == [0, 3]:
+                            lhs = cell_pids[offset]
+                            rhs = cell_pids[[1, 2]]
+                        else:
+                            emsg = (
+                                "Failed to unfold a mesh polar quad-cell. Invalid "
+                                "polar points connectivity detected."
+                            )
+                            raise ValueError(emsg)
+                        lons[lhs] = lons[rhs]
 
     if closed_interval:
         if GV_REMESH_POINT_IDS in mesh.point_data:

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -21,6 +21,8 @@ from pyvista.core.filters import _get_output
 from vtk import vtkLogger, vtkObject
 
 __all__ = [
+    "BASE",
+    "CENTRAL_MERIDIAN",
     "COASTLINES_RESOLUTION",
     "GV_CELL_IDS",
     "GV_FIELD_CRS",
@@ -31,12 +33,15 @@ __all__ = [
     "GV_POINT_IDS",
     "GV_REMESH_POINT_IDS",
     "LRU_CACHE_SIZE",
+    "PERIOD",
     "Preference",
     "RADIUS",
     "REMESH_JOIN",
     "REMESH_SEAM",
     "VTK_CELL_IDS",
     "VTK_POINT_IDS",
+    "WRAP_ATOL",
+    "WRAP_RTOL",
     "ZLEVEL_SCALE",
     "ZTRANSFORM_FACTOR",
     "cast_UnstructuredGrid_to_PolyData",
@@ -61,6 +66,9 @@ __all__ = [
 
 #: Default base for wrapped longitude half-open interval, in degrees.
 BASE: float = -180.0
+
+#: Default central meridian.
+CENTRAL_MERIDIAN: float = 0.0
 
 #: Default Natural Earth coastline resolution.
 COASTLINES_RESOLUTION: str = "10m"

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -38,6 +38,7 @@ __all__ = [
     "VTK_CELL_IDS",
     "VTK_POINT_IDS",
     "ZLEVEL_SCALE",
+    "ZTRANSFORM_FACTOR",
     "cast_UnstructuredGrid_to_PolyData",
     "distance",
     "from_cartesian",
@@ -120,6 +121,9 @@ WRAP_RTOL: float = 1.0e-5
 
 #: Proportional multiplier for z-axis levels/offsets.
 ZLEVEL_SCALE: float = 1.0e-4
+
+#: The zlevel scaling to be applied when transforming to a projection.
+ZTRANSFORM_FACTOR: int = 3
 
 
 class _MixinStrEnum:

--- a/src/geovista/config.py
+++ b/src/geovista/config.py
@@ -5,6 +5,8 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
+
 from os import environ
 from pathlib import Path
 

--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -669,7 +669,9 @@ def slice_cells(
     return result
 
 
-def slice_lines(mesh: pv.PolyData, n_points: int | None = None) -> pv.PolyData:
+def slice_lines(
+    mesh: pv.PolyData, n_points: int | None = None, copy: bool | None = False
+) -> pv.PolyData:
     """Cut the line mesh along the antimeridian, breaking line connectivity.
 
     The connectivity of any line segment in the mesh traversing the antimeridian will be
@@ -694,6 +696,9 @@ def slice_lines(mesh: pv.PolyData, n_points: int | None = None) -> pv.PolyData:
         plane which will slice the `mesh` e.g., with ``n_points=1``, a mid-point will be
         calculated for the line, which will then consist of 2 line segments i.e., the 2
         end-points and 1 mid-point. Defaults to :data:`SPLINE_N_POINTS`.
+    copy : bool, default=False
+        Return a deepcopy of the ``mesh`` when there are no points of intersection with
+        the antimeridian. Otherwise, the original ``mesh`` is returned.
 
     Notes
     -----
@@ -723,6 +728,8 @@ def slice_lines(mesh: pv.PolyData, n_points: int | None = None) -> pv.PolyData:
     antimeridian = np.isclose(lonlat[:, 0], -180)
 
     if antimeridian.sum() == 0:
+        if copy:
+            mesh = mesh.copy()
         return mesh
 
     # antimeridian points-of-interest (N, 3)

--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -591,8 +591,8 @@ def slice_cells(
         emsg = f"Require a {str(pv.PolyData)!r} mesh, got {str(type(mesh))!r}."
         raise TypeError(emsg)
 
-    if point_cloud(mesh):
-        # there is no connectivity or cell remeshing required for a point-cloud
+    if point_cloud(mesh) or mesh.n_lines:
+        # no cell remeshing required for a point-cloud or line mesh
         return mesh
 
     if meridian is None:
@@ -710,8 +710,8 @@ def slice_lines(
         raise ValueError(emsg)
 
     if mesh.n_lines == 0:
-        emsg = "Cannot slice a mesh containing no lines."
-        raise ValueError(emsg)
+        # there are no lines to slice
+        return mesh
 
     if n_points is None:
         n_points = SPLINE_N_POINTS
@@ -729,7 +729,7 @@ def slice_lines(
 
     if antimeridian.sum() == 0:
         if copy:
-            mesh = mesh.copy()
+            mesh = mesh.copy(deep=True)
         return mesh
 
     # antimeridian points-of-interest (N, 3)

--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -17,6 +17,7 @@ from numpy.typing import ArrayLike
 import pyvista as pv
 
 from .common import (
+    CENTRAL_MERIDIAN,
     GV_CELL_IDS,
     GV_FIELD_RADIUS,
     GV_FIELD_ZSCALE,
@@ -59,9 +60,6 @@ CUT_EAST: str = "EAST"
 
 #: Cartesian west/east bias offset of a slice.
 CUT_OFFSET: float = 1e-5
-
-#: By default, generate a mesh seam at this meridian.
-DEFAULT_MERIDIAN: float = 0.0
 
 #: The default number of interpolation points along a spline.
 SPLINE_N_POINTS: int = 1
@@ -268,7 +266,8 @@ def add_texture_coords(
     mesh : PolyData
         The mesh that requires texture coordinates.
     meridian : float, optional
-        The meridian (degrees longitude) to slice along.
+        The meridian (degrees longitude) to slice along. Defaults to
+        :data:`geovista.common.CENTRAL_MERIDIAN`.
     antimeridian : bool, default=False
         Whether to flip the given `meridian` to use its anti-meridian instead.
 
@@ -287,7 +286,7 @@ def add_texture_coords(
         return mesh
 
     if meridian is None:
-        meridian = DEFAULT_MERIDIAN
+        meridian = CENTRAL_MERIDIAN
 
     if antimeridian:
         meridian += 180
@@ -568,7 +567,8 @@ def slice_cells(
     mesh : PolyData
         The mesh to be sliced along the `meridian`.
     meridian : float, optional
-        The meridian (degrees longitude) to slice along.
+        The meridian (degrees longitude) to slice along. Defaults to
+        :data:`geovista.common.CENTRAL_MERIDIAN`.
     antimeridian : bool, default=False
         Whether to flip the given `meridian` to use its anti-meridian instead.
     rtol : float, optional
@@ -598,7 +598,7 @@ def slice_cells(
         return mesh
 
     if meridian is None:
-        meridian = DEFAULT_MERIDIAN
+        meridian = CENTRAL_MERIDIAN
 
     if antimeridian:
         meridian += 180

--- a/src/geovista/examples/from_1d__oisst.py
+++ b/src/geovista/examples/from_1d__oisst.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import oisst_avhrr_sst

--- a/src/geovista/examples/from_1d__oisst_eqc.py
+++ b/src/geovista/examples/from_1d__oisst_eqc.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import oisst_avhrr_sst

--- a/src/geovista/examples/from_1d__synthetic_face_m1_n1.py
+++ b/src/geovista/examples/from_1d__synthetic_face_m1_n1.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
+++ b/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_1d__synthetic_node_m1_n1.py
+++ b/src/geovista/examples/from_1d__synthetic_node_m1_n1.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
+++ b/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_2d__orca.py
+++ b/src/geovista/examples/from_2d__orca.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import um_orca2

--- a/src/geovista/examples/from_2d__orca_moll.py
+++ b/src/geovista/examples/from_2d__orca_moll.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import um_orca2

--- a/src/geovista/examples/from_2d__synthetic_face_m1n1.py
+++ b/src/geovista/examples/from_2d__synthetic_face_m1n1.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
+++ b/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_2d__synthetic_node_m1n1.py
+++ b/src/geovista/examples/from_2d__synthetic_node_m1n1.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
+++ b/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import numpy as np
 

--- a/src/geovista/examples/from_points__orca_cloud.py
+++ b/src/geovista/examples/from_points__orca_cloud.py
@@ -5,6 +5,7 @@ Notes
 .. versionadded:: 0.2.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import um_orca2_gradient

--- a/src/geovista/examples/from_points__orca_cloud_eqc.py
+++ b/src/geovista/examples/from_points__orca_cloud_eqc.py
@@ -5,6 +5,7 @@ Notes
 .. versionadded:: 0.3.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import um_orca2_gradient

--- a/src/geovista/examples/from_unstructured__fesom.py
+++ b/src/geovista/examples/from_unstructured__fesom.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import fesom

--- a/src/geovista/examples/from_unstructured__fesom_fouc.py
+++ b/src/geovista/examples/from_unstructured__fesom_fouc.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import fesom

--- a/src/geovista/examples/from_unstructured__fvcom.py
+++ b/src/geovista/examples/from_unstructured__fvcom.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import fvcom_tamar

--- a/src/geovista/examples/from_unstructured__icon.py
+++ b/src/geovista/examples/from_unstructured__icon.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import matplotlib as mpl
 

--- a/src/geovista/examples/from_unstructured__icon_eqc.py
+++ b/src/geovista/examples/from_unstructured__icon_eqc.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import matplotlib as mpl
 

--- a/src/geovista/examples/from_unstructured__icosahedral.py
+++ b/src/geovista/examples/from_unstructured__icosahedral.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.3.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import icosahedral

--- a/src/geovista/examples/from_unstructured__icosahedral_poly.py
+++ b/src/geovista/examples/from_unstructured__icosahedral_poly.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import icosahedral

--- a/src/geovista/examples/from_unstructured__lam_pacific.py
+++ b/src/geovista/examples/from_unstructured__lam_pacific.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import lam_pacific

--- a/src/geovista/examples/from_unstructured__lam_pacific_moll.py
+++ b/src/geovista/examples/from_unstructured__lam_pacific_moll.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import lam_pacific

--- a/src/geovista/examples/from_unstructured__lfric_orog.py
+++ b/src/geovista/examples/from_unstructured__lfric_orog.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import lfric_orog

--- a/src/geovista/examples/from_unstructured__lfric_orog_warp.py
+++ b/src/geovista/examples/from_unstructured__lfric_orog_warp.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import lfric_orog

--- a/src/geovista/examples/from_unstructured__lfric_sst.py
+++ b/src/geovista/examples/from_unstructured__lfric_sst.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import lfric_sst

--- a/src/geovista/examples/from_unstructured__lfric_sst_bonne.py
+++ b/src/geovista/examples/from_unstructured__lfric_sst_bonne.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import lfric_sst

--- a/src/geovista/examples/from_unstructured__smc.py
+++ b/src/geovista/examples/from_unstructured__smc.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import ww3_global_smc

--- a/src/geovista/examples/from_unstructured__smc_sinu.py
+++ b/src/geovista/examples/from_unstructured__smc_sinu.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import ww3_global_smc

--- a/src/geovista/examples/from_unstructured__tri.py
+++ b/src/geovista/examples/from_unstructured__tri.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import ww3_global_tri

--- a/src/geovista/examples/from_unstructured__tri_hammer.py
+++ b/src/geovista/examples/from_unstructured__tri_hammer.py
@@ -6,6 +6,7 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
 
 import geovista as gv
 from geovista.pantry import ww3_global_tri

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -351,7 +351,6 @@ class GeoPlotterBase:
         lat_start: float | None = None,
         lat_step: float | None = None,
         lat_stop: float | None = None,
-        n_samples: int | None = None,
         poles_parallel: bool | None = None,
         poles_label: bool | None = None,
         show_labels: bool | None = None,
@@ -370,37 +369,35 @@ class GeoPlotterBase:
         Parameters
         ----------
         lon_start : float, optional
-            The starting line of longitude (degrees). The graticule will include this
+            The first line of longitude (degrees). The graticule will include this
             meridian. Defaults to :data:`geovista.gridlines.LONGITUDE_START`.
         lon_stop : float, optional
             The last line of longitude (degrees). The graticule will include this
-            meridian when it is a multiple of ``step``. Defaults to
-            :data:`geovista.gridlines.LONGITUDE_STOP`.
+            meridian when it is a multiple of ``lon_step``. Also see
+            ``closed_interval``. Defaults to :data:`geovista.gridlines.LONGITUDE_STOP`.
         lon_step : float, optional
             The delta (degrees) between neighbouring meridians. Defaults to
             :data:`geovista.gridlines.LONGITUDE_STEP`.
         lat_start : float, optional
-            The starting line of latitude (degrees). The graticule will include this
-            parallel. Defaults to :data:`geovista.gridlines.LATITUDE_START`.
+            The first line of latitude (degrees). The graticule will include this
+            parallel. Also see `poles_parallel`. Defaults to
+            :data:`geovista.gridlines.LATITUDE_START`.
         lat_stop : float, optional
             The last line of latitude (degrees). The graticule will include this
-            parallel when it is a multiple of ``step``. Defaults to
+            parallel when it is a multiple of ``lat_step``. Defaults to
             :data:`geovista.gridlines.LATITUDE_STOP`.
         lat_step : float, optional
             The delta (degrees) between neighbouring parallels. Defaults to
             :data:`geovista.gridlines.LATITUDE_STEP`.
-        n_samples : int, optional
-            The number of points in a single line of latitude. Defaults to
-            :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
         poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
         poles_label : bool, optional
             Whether to create a single north/south pole label. Only applies when
-            ``poles=False``. Defaults to
+            ``poles_parallel=False``. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_LABEL`.
         show_labels : bool, optional
-            Whether to render the labels of the parallels. Defaults to
+            Whether to render the labels of the parallels and meridians. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
         closed_interval : bool, optional
             Longitude values will be in the half-closed interval [-180, 180). Otherwise,
@@ -430,7 +427,6 @@ class GeoPlotterBase:
             stop=lon_stop,
             step=lon_step,
             lat_step=lat_step,
-            n_samples=n_samples,
             show_labels=show_labels,
             closed_interval=closed_interval,
             radius=radius,
@@ -444,7 +440,6 @@ class GeoPlotterBase:
             stop=lat_stop,
             step=lat_step,
             lon_step=lon_step,
-            n_samples=n_samples,
             poles_parallel=poles_parallel,
             poles_label=poles_label,
             show_labels=show_labels,
@@ -596,7 +591,7 @@ class GeoPlotterBase:
             The number of points in a single line of longitude. Defaults to
             :data:`geovista.gridlines.LONGITUDE_N_SAMPLES`.
         show_labels : bool, optional
-            Whether to render the labels of the parallels. Defaults to
+            Whether to render the meridian label. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
         closed_interval : bool, optional
             Longitude values will be in the half-closed interval [-180, 180). Otherwise,
@@ -655,12 +650,12 @@ class GeoPlotterBase:
         Parameters
         ----------
         start : float, optional
-            The starting line of longitude (degrees). The graticule will include this
+            The first line of longitude (degrees). The graticule will include this
             meridian. Defaults to :data:`geovista.gridlines.LONGITUDE_START`.
         stop : float, optional
             The last line of longitude (degrees). The graticule will include this
-            meridian when it is a multiple of ``step``. Defaults to
-            :data:`geovista.gridlines.LONGITUDE_STOP`.
+            meridian when it is a multiple of ``step``. Also see ``closed_interval``.
+            Defaults to :data:`geovista.gridlines.LONGITUDE_STOP`.
         step : float, optional
             The delta (degrees) between neighbouring meridians. Defaults to
             :data:`geovista.gridlines.LONGITUDE_STEP`.
@@ -671,7 +666,7 @@ class GeoPlotterBase:
             The number of points in a single line of longitude. Defaults to
             :data:`geovista.gridlines.LONGITUDE_N_SAMPLES`.
         show_labels : bool, optional
-            Whether to render the labels of the parallels. Defaults to
+            Whether to render the labels of the meridians. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
         closed_interval : bool, optional
             Longitude values will be in the half-closed interval [-180, 180). Otherwise,
@@ -761,7 +756,7 @@ class GeoPlotterBase:
             Whether to create a line of latitude at the north/south poles. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
         show_labels : bool, optional
-            Whether to render the labels of the parallels. Defaults to
+            Whether to render the parallel label. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
         radius : float, optional
             The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
@@ -817,12 +812,13 @@ class GeoPlotterBase:
         Parameters
         ----------
         start : float, optional
-            The starting line of latitude (degrees). The graticule will include this
-            parallel. Defaults to :data:`geovista.gridlines.LATITUDE_START`.
+            The first line of latitude (degrees). The graticule will include this
+            parallel. Also see ``poles_parallel``. Defaults to
+            :data:`geovista.gridlines.LATITUDE_START`.
         stop : float, optional
             The last line of latitude (degrees). The graticule will include this
-            parallel when it is a multiple of ``step``. Defaults to
-            :data:`geovista.gridlines.LATITUDE_STOP`.
+            parallel when it is a multiple of ``step``. Also see ``poles_parallel`.
+            Defaults to :data:`geovista.gridlines.LATITUDE_STOP`.
         step : float, optional
             The delta (degrees) between neighbouring parallels. Defaults to
             :data:`geovista.gridlines.LATITUDE_STEP`.
@@ -837,7 +833,7 @@ class GeoPlotterBase:
             :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
         poles_label : bool, optional
             Whether to create a single north/south pole label. Only applies when
-            ``poles=False``. Defaults to
+            ``poles_parallel=False``. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_LABEL`.
         show_labels : bool, optional
             Whether to render the labels of the parallels. Defaults to

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -352,9 +352,10 @@ class GeoPlotterBase:
         lat_step: float | None = None,
         lat_stop: float | None = None,
         n_samples: int | None = None,
-        poles: bool | None = None,
+        poles_parallel: bool | None = None,
         poles_label: bool | None = None,
         show_labels: bool | None = None,
+        closed_interval: bool | None = None,
         radius: float | None = None,
         zlevel: int | None = None,
         zscale: float | None = None,
@@ -391,9 +392,9 @@ class GeoPlotterBase:
         n_samples : int, optional
             The number of points in a single line of latitude. Defaults to
             :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
-        poles : bool, optional
+        poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
-            :data:`geovista.gridlines.LATITUDE_POLES`.
+            :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
         poles_label : bool, optional
             Whether to create a single north/south pole label. Only applies when
             ``poles=False``. Defaults to
@@ -401,6 +402,10 @@ class GeoPlotterBase:
         show_labels : bool, optional
             Whether to render the labels of the parallels. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
+        closed_interval : bool, optional
+            Longitude values will be in the half-closed interval [-180, 180). Otherwise,
+            longitudes will be in the closed interval [-180, 180]. Defaults to
+            :data:`geovista.gridlines.GRATICULE_CLOSED_INTERVAL`.
         radius : float, optional
             The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
         zlevel : int, optional
@@ -427,6 +432,7 @@ class GeoPlotterBase:
             lat_step=lat_step,
             n_samples=n_samples,
             show_labels=show_labels,
+            closed_interval=closed_interval,
             radius=radius,
             zlevel=zlevel,
             zscale=zscale,
@@ -439,7 +445,7 @@ class GeoPlotterBase:
             step=lat_step,
             lon_step=lon_step,
             n_samples=n_samples,
-            poles=poles,
+            poles_parallel=poles_parallel,
             poles_label=poles_label,
             show_labels=show_labels,
             radius=radius,
@@ -511,7 +517,7 @@ class GeoPlotterBase:
                     tgt_crs = set_central_meridian(tgt_crs, 0)
 
                 cut_mesh = (
-                    slice_lines(mesh)
+                    slice_lines(mesh, copy=True)
                     if mesh.n_lines
                     else slice_cells(mesh, antimeridian=True, rtol=rtol, atol=atol)
                 )
@@ -570,6 +576,7 @@ class GeoPlotterBase:
         lat_step: float | None = None,
         n_samples: int | None = None,
         show_labels: bool | None = None,
+        closed_interval: bool | None = None,
         radius: float | None = None,
         zlevel: int | None = None,
         zscale: float | None = None,
@@ -591,6 +598,10 @@ class GeoPlotterBase:
         show_labels : bool, optional
             Whether to render the labels of the parallels. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
+        closed_interval : bool, optional
+            Longitude values will be in the half-closed interval [-180, 180). Otherwise,
+            longitudes will be in the closed interval [-180, 180]. Defaults to
+            :data:`geovista.gridlines.GRATICULE_CLOSED_INTERVAL`.
         radius : float, optional
             The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
         zlevel : int, optional
@@ -616,6 +627,7 @@ class GeoPlotterBase:
             lat_step=lat_step,
             n_samples=n_samples,
             show_labels=show_labels,
+            closed_interval=closed_interval,
             radius=radius,
             zlevel=zlevel,
             zscale=zscale,
@@ -631,6 +643,7 @@ class GeoPlotterBase:
         lat_step: float | None = None,
         n_samples: int | None = None,
         show_labels: bool | None = None,
+        closed_interval: bool | None = None,
         radius: float | None = None,
         zlevel: int | None = None,
         zscale: float | None = None,
@@ -660,6 +673,10 @@ class GeoPlotterBase:
         show_labels : bool, optional
             Whether to render the labels of the parallels. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
+        closed_interval : bool, optional
+            Longitude values will be in the half-closed interval [-180, 180). Otherwise,
+            longitudes will be in the closed interval [-180, 180]. Defaults to
+            :data:`geovista.gridlines.GRATICULE_CLOSED_INTERVAL`.
         radius : float, optional
             The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
         zlevel : int, optional
@@ -697,6 +714,7 @@ class GeoPlotterBase:
             step=step,
             lat_step=lat_step,
             n_samples=n_samples,
+            closed_interval=closed_interval,
             radius=radius,
             zlevel=zlevel,
             zscale=zscale,
@@ -719,7 +737,7 @@ class GeoPlotterBase:
         lat: float,
         lon_step: float | None = None,
         n_samples: int | None = None,
-        poles: bool | None = None,
+        poles_parallel: bool | None = None,
         show_labels: bool | None = None,
         radius: float | None = None,
         zlevel: int | None = None,
@@ -739,9 +757,9 @@ class GeoPlotterBase:
         n_samples : int, optional
             The number of points in a single line of latitude. Defaults to
             :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
-        poles : bool, optional
+        poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
-            :data:`geovista.gridlines.LATITUDE_POLES`.
+            :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
         show_labels : bool, optional
             Whether to render the labels of the parallels. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
@@ -769,7 +787,7 @@ class GeoPlotterBase:
             stop=lat,
             lon_step=lon_step,
             n_samples=n_samples,
-            poles=poles,
+            poles_parallel=poles_parallel,
             show_labels=show_labels,
             radius=radius,
             zlevel=zlevel,
@@ -785,7 +803,7 @@ class GeoPlotterBase:
         step: float | None = None,
         lon_step: float | None = None,
         n_samples: int | None = None,
-        poles: bool | None = None,
+        poles_parallel: bool | None = None,
         poles_label: bool | None = None,
         show_labels: bool | None = None,
         radius: float | None = None,
@@ -814,9 +832,9 @@ class GeoPlotterBase:
         n_samples : int, optional
             The number of points in a single line of latitude. Defaults to
             :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
-        poles : bool, optional
+        poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
-            :data:`geovista.gridlines.LATITUDE_POLES`.
+            :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
         poles_label : bool, optional
             Whether to create a single north/south pole label. Only applies when
             ``poles=False``. Defaults to
@@ -861,7 +879,7 @@ class GeoPlotterBase:
             step=step,
             lon_step=lon_step,
             n_samples=n_samples,
-            poles=poles,
+            poles_parallel=poles_parallel,
             poles_label=poles_label,
             radius=radius,
             zlevel=zlevel,

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -207,9 +207,9 @@ class GeoPlotterBase:
             mesh.set_active_scalars(name=None)
 
         to_wkt(mesh, WGS84)
-        mesh = transform_mesh(
-            mesh, self.crs, slice_connectivity=False, zlevel=zlevel, inplace=True
-        )
+        # the point-cloud won't be sliced, however it's important that the
+        # central-meridian rotation is performed here
+        mesh = transform_mesh(mesh, self.crs, zlevel=zlevel, inplace=True)
         xyz = mesh.points
 
         if "show_points" in point_labels_args:
@@ -702,6 +702,7 @@ class GeoPlotterBase:
             point_labels_args = {}
 
         closed_interval = self.crs.is_projected
+        central_meridian = get_central_meridian(self.crs)
 
         meridians = create_meridians(
             start=start,
@@ -710,6 +711,7 @@ class GeoPlotterBase:
             lat_step=lat_step,
             n_samples=n_samples,
             closed_interval=closed_interval,
+            central_meridian=central_meridian,
             radius=radius,
             zlevel=zlevel,
             zscale=zscale,

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -154,10 +154,27 @@ class GeoPlotterBase:
         zscale: float | None = None,
         point_labels_args: dict[Any, Any] | None = None,
     ) -> None:
-        """TBD.
+        """Render the labels for the given parallels/meridians.
 
-        Note
-        ----
+        Parameters
+        ----------
+        graticule : GraticuleGrid
+            The labels and associated lon/lat points for the graticule
+            parallels/meridians.
+        radius : float, optional
+            The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+        zlevel : int, optional
+            The z-axis level. Used in combination with the `zscale` to offset the
+            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+            Defaults to :data:`geovista.gridlines.GRATICULE_ZLEVEL`
+        zscale : float, optional
+            The proportional multiplier for z-axis `zlevel`. Defaults to
+            :data:`geovista.common.ZLEVEL_SCALE`.
+        point_labels_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+
+        Notes
+        -----
         .. versionadded:: 0.3.0
 
         """
@@ -167,6 +184,7 @@ class GeoPlotterBase:
         if point_labels_args is None:
             point_labels_args = {}
 
+        # TBD: projection support required here
         lonlat = graticule.lonlat
         xyz = to_cartesian(
             lonlat[:, 0], lonlat[:, 1], radius=radius, zlevel=zlevel, zscale=zscale
@@ -227,7 +245,7 @@ class GeoPlotterBase:
         resolution = kwargs.pop("resolution") if "resolution" in kwargs else None
 
         if self.crs.is_projected:
-            # pass-through "zlevel" and "zscale" to the "add_mesh" method,
+            # pass through "zlevel" and "zscale" to the "add_mesh" method,
             # but remove "radius", as it's not applicable to planar projections
             if "radius" in kwargs:
                 _ = kwargs.pop("radius")
@@ -301,14 +319,14 @@ class GeoPlotterBase:
 
         """
         if self.crs.is_projected:
-            # don't pass-through "radius", as it's not applicable
+            # don't pass through "radius", as it's not applicable
             if rtol is None:
                 rtol = COASTLINES_RTOL
             if zscale is None:
                 zscale = ZLEVEL_SCALE
             if zlevel is None:
                 zlevel = 5
-            # pass-through kwargs to "add_mesh"
+            # pass through kwargs to "add_mesh"
             kwargs.update({"zlevel": zlevel, "zscale": zscale})
 
         mesh = coastlines(
@@ -343,10 +361,62 @@ class GeoPlotterBase:
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
     ) -> None:
-        """TBD.
+        """Generate a graticule and add to the plotter scene.
 
-        Note
-        ----
+        This involves generating lines of constant latitude (parallels) and
+        lines of constant longitude (meridians), which together form the graticule.
+
+        Parameters
+        ----------
+        lon_start : float, optional
+            The starting line of longitude (degrees). The graticule will include this
+            meridian. Defaults to :data:`geovista.gridlines.LONGITUDE_START`.
+        lon_stop : float, optional
+            The last line of longitude (degrees). The graticule will include this
+            meridian when it is a multiple of ``step``. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_STOP`.
+        lon_step : float, optional
+            The delta (degrees) between neighbouring meridians. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_STEP`.
+        lat_start : float, optional
+            The starting line of latitude (degrees). The graticule will include this
+            parallel. Defaults to :data:`geovista.gridlines.LATITUDE_START`.
+        lat_stop : float, optional
+            The last line of latitude (degrees). The graticule will include this
+            parallel when it is a multiple of ``step``. Defaults to
+            :data:`geovista.gridlines.LATITUDE_STOP`.
+        lat_step : float, optional
+            The delta (degrees) between neighbouring parallels. Defaults to
+            :data:`geovista.gridlines.LATITUDE_STEP`.
+        n_samples : int, optional
+            The number of points in a single line of latitude. Defaults to
+            :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
+        poles : bool, optional
+            Whether to create a line of latitude at the north/south poles. Defaults to
+            :data:`geovista.gridlines.LATITUDE_POLES`.
+        poles_label : bool, optional
+            Whether to create a single north/south pole label. Only applies when
+            ``poles=False``. Defaults to
+            :data:`geovista.gridlines.LATITUDE_POLES_LABEL`.
+        show_labels : bool, optional
+            Whether to render the labels of the parallels. Defaults to
+            :data:`GRATICULE_SHOW_LABELS`.
+        radius : float, optional
+            The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+        zlevel : int, optional
+            The z-axis level. Used in combination with the `zscale` to offset the
+            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+            Defaults to :data:`geovista.gridlines.GRATICULE_ZLEVEL`
+        zscale : float, optional
+            The proportional multiplier for z-axis `zlevel`. Defaults to
+            :data:`geovista.common.ZLEVEL_SCALE`.
+        mesh_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
+        point_labels_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+
+        Notes
+        -----
         .. versionadded:: 0.3.0
 
         """
@@ -506,10 +576,37 @@ class GeoPlotterBase:
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
     ) -> None:
-        """TBD.
+        """Generate a line of constant longitude and add to the plotter scene.
 
-        Note
-        ----
+        Parameters
+        ----------
+        lon : float
+            The constant line of longitude (degrees) to generate.
+        lat_step : float, optional
+            The delta (degrees) between neighbouring parallels. Defaults to
+            :data:`geovista.gridlines.LATITUDE_STEP`.
+        n_samples : int, optional
+            The number of points in a single line of longitude. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_N_SAMPLES`.
+        show_labels : bool, optional
+            Whether to render the labels of the parallels. Defaults to
+            :data:`GRATICULE_SHOW_LABELS`.
+        radius : float, optional
+            The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+        zlevel : int, optional
+            The z-axis level. Used in combination with the `zscale` to offset the
+            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+            Defaults to :data:`geovista.gridlines.GRATICULE_ZLEVEL`
+        zscale : float, optional
+            The proportional multiplier for z-axis `zlevel`. Defaults to
+            :data:`geovista.common.ZLEVEL_SCALE`.
+        mesh_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
+        point_labels_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+
+        Notes
+        -----
         .. versionadded:: 0.3.0
 
         """
@@ -540,10 +637,45 @@ class GeoPlotterBase:
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
     ) -> None:
-        """TBD.
+        """Generate lines of constant longitude and add to the plotter scene.
 
-        Note
-        ----
+        Parameters
+        ----------
+        start : float, optional
+            The starting line of longitude (degrees). The graticule will include this
+            meridian. Defaults to :data:`geovista.gridlines.LONGITUDE_START`.
+        stop : float, optional
+            The last line of longitude (degrees). The graticule will include this
+            meridian when it is a multiple of ``step``. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_STOP`.
+        step : float, optional
+            The delta (degrees) between neighbouring meridians. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_STEP`.
+        lat_step : float, optional
+            The delta (degrees) between neighbouring parallels. Defaults to
+            :data:`geovista.gridlines.LATITUDE_STEP`.
+        n_samples : int, optional
+            The number of points in a single line of longitude. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_N_SAMPLES`.
+        show_labels : bool, optional
+            Whether to render the labels of the parallels. Defaults to
+            :data:`GRATICULE_SHOW_LABELS`.
+        radius : float, optional
+            The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+        zlevel : int, optional
+            The z-axis level. Used in combination with the `zscale` to offset the
+            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+            Defaults to :data:`geovista.gridlines.GRATICULE_ZLEVEL`
+        zscale : float, optional
+            The proportional multiplier for z-axis `zlevel`. Defaults to
+            :data:`geovista.common.ZLEVEL_SCALE`.
+        mesh_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
+        point_labels_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+
+        Notes
+        -----
         .. versionadded:: 0.3.0
 
         """
@@ -595,10 +727,40 @@ class GeoPlotterBase:
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
     ) -> None:
-        """TBD.
+        """Generate a line of constant latitude and add to the plotter scene.
 
-        Note
-        ----
+        Parameters
+        ----------
+        lat : float
+            The constant line of latitude (degrees) to generate.
+        lon_step : float, optional
+            The delta (degrees) between neighbouring meridians. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_STEP`.
+        n_samples : int, optional
+            The number of points in a single line of latitude. Defaults to
+            :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
+        poles : bool, optional
+            Whether to create a line of latitude at the north/south poles. Defaults to
+            :data:`geovista.gridlines.LATITUDE_POLES`.
+        show_labels : bool, optional
+            Whether to render the labels of the parallels. Defaults to
+            :data:`GRATICULE_SHOW_LABELS`.
+        radius : float, optional
+            The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+        zlevel : int, optional
+            The z-axis level. Used in combination with the `zscale` to offset the
+            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+            Defaults to :data:`geovista.gridlines.GRATICULE_ZLEVEL`
+        zscale : float, optional
+            The proportional multiplier for z-axis `zlevel`. Defaults to
+            :data:`geovista.common.ZLEVEL_SCALE`.
+        mesh_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
+        point_labels_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+
+        Notes
+        -----
         .. versionadded:: 0.3.0
 
         """
@@ -632,10 +794,52 @@ class GeoPlotterBase:
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
     ) -> None:
-        """TBD.
+        """Generate lines of constant latitude and add to the plotter scene.
 
-        Note
-        ----
+        Parameters
+        ----------
+        start : float, optional
+            The starting line of latitude (degrees). The graticule will include this
+            parallel. Defaults to :data:`geovista.gridlines.LATITUDE_START`.
+        stop : float, optional
+            The last line of latitude (degrees). The graticule will include this
+            parallel when it is a multiple of ``step``. Defaults to
+            :data:`geovista.gridlines.LATITUDE_STOP`.
+        step : float, optional
+            The delta (degrees) between neighbouring parallels. Defaults to
+            :data:`geovista.gridlines.LATITUDE_STEP`.
+        lon_step : float, optional
+            The delta (degrees) between neighbouring meridians. Defaults to
+            :data:`geovista.gridlines.LONGITUDE_STEP`.
+        n_samples : int, optional
+            The number of points in a single line of latitude. Defaults to
+            :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
+        poles : bool, optional
+            Whether to create a line of latitude at the north/south poles. Defaults to
+            :data:`geovista.gridlines.LATITUDE_POLES`.
+        poles_label : bool, optional
+            Whether to create a single north/south pole label. Only applies when
+            ``poles=False``. Defaults to
+            :data:`geovista.gridlines.LATITUDE_POLES_LABEL`.
+        show_labels : bool, optional
+            Whether to render the labels of the parallels. Defaults to
+            :data:`GRATICULE_SHOW_LABELS`.
+        radius : float, optional
+            The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+        zlevel : int, optional
+            The z-axis level. Used in combination with the `zscale` to offset the
+            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+            Defaults to :data:`geovista.gridlines.GRATICULE_ZLEVEL`
+        zscale : float, optional
+            The proportional multiplier for z-axis `zlevel`. Defaults to
+            :data:`geovista.common.ZLEVEL_SCALE`.
+        mesh_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
+        point_labels_args : dict, optional
+            Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+
+        Notes
+        -----
         .. versionadded:: 0.3.0
 
         """

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -98,6 +98,29 @@ class GraticuleGrid:
     labels: list[str, ...]
 
 
+def _step_modulo(lon_step: float, lat_step: float) -> tuple[float, float]:
+    """Wrap graticule meridian/parallel step size (degrees) to sane upper bounds.
+
+    Parameters
+    ----------
+    lon_step : float
+        The longitude step (degrees) between meridians.
+    lat_step : float
+        The latitude step (degrees) between parallels.
+
+    Returns
+    -------
+    tuple of float
+        The lon/lat step values.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.0
+
+    """
+    return (lon_step % LONGITUDE_STEP_MODULO, lat_step % LATITUDE_STEP_MODULO)
+
+
 def create_meridian_labels(lons: list[float, ...]) -> list[str, ...]:
     """Generate labels for the meridians.
 
@@ -133,79 +156,6 @@ def create_meridian_labels(lons: list[float, ...]) -> list[str, ...]:
         result.append(f"{value}{direction}")
 
     return result
-
-
-def create_parallel_labels(
-    lats: list[float, ...], poles_parallel: bool | None = None
-) -> list[str, ...]:
-    """Generate labels for the parallels.
-
-    Parameters
-    ----------
-    lats : list of float
-        The lines of latitude that require a label of their location north or
-        south of the prime meridian.
-    poles_parallel : bool, optional
-        Whether to generate a label for the north/south poles. Defaults to
-        :data:`LATITUDE_POLES_PARALLEL`.
-
-    Returns
-    -------
-    list of str
-        The sequence of string labels for each line of latitude.
-
-    Notes
-    -----
-    .. versionadded:: 0.3.0
-
-    """
-    result = []
-
-    if poles_parallel is None:
-        poles_parallel = LATITUDE_POLES_PARALLEL
-
-    if not isinstance(lats, Iterable):
-        lats = [lats]
-
-    for lat in lats:
-        direction = ""
-        if lat > 0:
-            direction = LABEL_NORTH
-        elif lat < 0:
-            direction = LABEL_SOUTH
-        elif lat == 0:
-            direction = LABEL_DEGREE
-
-        if not poles_parallel and np.isclose(np.abs(lat), 90.0):
-            continue
-
-        value = int(np.abs(lat)) if direction else ""
-        result.append(f"{value}{direction}")
-
-    return result
-
-
-def _step_modulo(lon_step: float, lat_step: float) -> tuple[float, float]:
-    """Wrap graticule meridian/parallel step size (degrees) to sane upper bounds.
-
-    Parameters
-    ----------
-    lon_step : float
-        The longitude step (degrees) between meridians.
-    lat_step : float
-        The latitude step (degrees) between parallels.
-
-    Returns
-    -------
-    tuple of float
-        The lon/lat step values.
-
-    Notes
-    -----
-    .. versionadded:: 0.3.0
-
-    """
-    return (lon_step % LONGITUDE_STEP_MODULO, lat_step % LATITUDE_STEP_MODULO)
 
 
 def create_meridians(
@@ -340,6 +290,56 @@ def create_meridians(
     graticule = GraticuleGrid(blocks=blocks, lonlat=grid_points, labels=grid_labels)
 
     return graticule
+
+
+def create_parallel_labels(
+    lats: list[float, ...], poles_parallel: bool | None = None
+) -> list[str, ...]:
+    """Generate labels for the parallels.
+
+    Parameters
+    ----------
+    lats : list of float
+        The lines of latitude that require a label of their location north or
+        south of the prime meridian.
+    poles_parallel : bool, optional
+        Whether to generate a label for the north/south poles. Defaults to
+        :data:`LATITUDE_POLES_PARALLEL`.
+
+    Returns
+    -------
+    list of str
+        The sequence of string labels for each line of latitude.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.0
+
+    """
+    result = []
+
+    if poles_parallel is None:
+        poles_parallel = LATITUDE_POLES_PARALLEL
+
+    if not isinstance(lats, Iterable):
+        lats = [lats]
+
+    for lat in lats:
+        direction = ""
+        if lat > 0:
+            direction = LABEL_NORTH
+        elif lat < 0:
+            direction = LABEL_SOUTH
+        elif lat == 0:
+            direction = LABEL_DEGREE
+
+        if not poles_parallel and np.isclose(np.abs(lat), 90.0):
+            continue
+
+        value = int(np.abs(lat)) if direction else ""
+        result.append(f"{value}{direction}")
+
+    return result
 
 
 def create_parallels(

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -135,8 +135,8 @@ def create_meridian_labels(lons: list[float, ...]) -> list[str, ...]:
     Parameters
     ----------
     lons : list of float
-        The meridian lines that require a label of their location east or west of
-        the prime meridian.
+        The meridian lines that require a label of their location east or west relative
+        to the prime meridian.
 
     Returns
     -------
@@ -154,13 +154,16 @@ def create_meridian_labels(lons: list[float, ...]) -> list[str, ...]:
         lons = [lons]
 
     for lon in lons:
+        # explicit truncation, perhaps offer format control when required
+        lon = int(lon)
         direction = LABEL_EAST
-        if lon == 0 or np.isclose(np.abs(lon), 180.0):
+
+        if lon == 0 or np.isclose(np.abs(lon), 180):
             direction = LABEL_DEGREE
         elif lon < 0:
             direction = LABEL_WEST
 
-        value = int(np.abs(lon))
+        value = np.abs(lon)
         result.append(f"{value}{direction}")
 
     return result
@@ -309,7 +312,7 @@ def create_parallel_labels(
     ----------
     lats : list of float
         The lines of latitude that require a label of their location north or
-        south of the prime meridian.
+        south relative to the equator.
     poles_parallel : bool, optional
         Whether to generate a label for the north/south poles. Defaults to
         :data:`LATITUDE_POLES_PARALLEL`.
@@ -333,18 +336,19 @@ def create_parallel_labels(
         lats = [lats]
 
     for lat in lats:
-        direction = ""
-        if lat > 0:
-            direction = LABEL_NORTH
+        # explicit truncation, perhaps offer format control when required
+        lat = int(lat)
+        direction = LABEL_NORTH
+
+        if lat == 0:
+            direction = LABEL_DEGREE
         elif lat < 0:
             direction = LABEL_SOUTH
-        elif lat == 0:
-            direction = LABEL_DEGREE
 
-        if not poles_parallel and np.isclose(np.abs(lat), 90.0):
+        if not poles_parallel and np.isclose(np.abs(lat), 90):
             continue
 
-        value = int(np.abs(lat)) if direction else ""
+        value = np.abs(lat)
         result.append(f"{value}{direction}")
 
     return result

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -122,8 +122,6 @@ def create_meridian_labels(lons: list[float, ...]) -> list[str, ...]:
     if not isinstance(lons, Iterable):
         lons = [lons]
 
-    print(f"create_meridian_labels: {lons=}")
-
     for lon in lons:
         direction = LABEL_EAST
         if lon == 0 or np.isclose(np.abs(lon), 180.0):

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -1,0 +1,264 @@
+"""Provides graticule support and other geographical lines of interest for geolocation.
+
+Notes
+-----
+.. versionadded:: 0.3.0
+
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike
+import pyvista as pv
+
+from .common import to_cartesian, wrap
+from .crs import WGS84, to_wkt
+
+__all__ = [
+    "create_parallels",
+]
+
+#: The degree symbol label.
+LABEL_DEGREE: str = "°"
+
+#: The east of the prime meridian label.
+LABEL_EAST: str = f"{LABEL_DEGREE}E"
+
+#: The north of the equatorial parallel label.
+LABEL_NORTH: str = f"{LABEL_DEGREE}N"
+
+#: The south of the equatorial parallel label.
+LABEL_SOUTH: str = f"{LABEL_DEGREE}S"
+
+#: The west of the prime meridian label.
+LABEL_WEST: str = f"{LABEL_DEGREE}W"
+
+#: The default number of points in a line of latitude.
+LATITUDE_N_SAMPLES: int = 360
+
+#: Whether to generate a label for the equatorial parallel.
+LATITUDE_LABEL_EQUATOR: bool = False
+
+#: Whether to generate a label for the north/south poles.
+LATITUDE_LABEL_POLES: bool = False
+
+#: The first graticule line of latitude (degrees).
+LATITUDE_START: float = -90.0
+
+#: The default step size between graticule parallels (degrees).
+LATITUDE_STEP: float = 30.0
+
+#: The last graticule line of latitude (degrees).
+LATITUDE_STOP: float = 90.0
+
+# The default number of points in a meridian line.
+LONGITUDE_N_SAMPLES: int = 180
+
+#: The first meridian line in the graticule (degrees).
+LONGITUDE_START: float = -180.0
+
+#: The default step size between graticule meridians (degrees).
+LONGITUDE_STEP: float = 30.0
+
+#: The last graticule meridian (degrees).
+LONGITUDE_STOP: float = 180.0
+
+
+@dataclass
+class GraticuleGrid:
+    """Graticule grid composed of the grid mesh, labels and their points."""
+
+    mesh: pv.PolyData
+    points: ArrayLike  # geographical lon/lat
+    labels: list[str, ...]
+
+
+def create_parallel_labels(
+    lats: list[float, ...], equator: bool | None = None, poles: bool | None = None
+) -> list[str, ...]:
+    """Generate labels for the parallels.
+
+    Parameters
+    ----------
+    lats : list of float
+        The lines of latitude that require a label of their location north or
+        south of the prime meridian.
+    equator : bool, optional
+        Whether to generate a populated or empty label for the equatorial parallel.
+        Defaults to :data:`LATITUDE_LABEL_EQUATOR`.
+    poles : bool, optional
+        Whether to generate a label for the north/south poles. Defaults to
+        :data:`LATITUDE_LABEL_POLES`.
+
+    Returns
+    -------
+    list of str
+        The sequence of string labels for each line of latitude.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.0
+
+    """
+    result = []
+
+    if equator is None:
+        equator = LATITUDE_LABEL_EQUATOR
+
+    if poles is None:
+        poles = LATITUDE_LABEL_POLES
+
+    for lat in lats:
+        direction = ""
+        if lat > 0:
+            direction = LABEL_NORTH
+        elif lat < 0:
+            direction = LABEL_SOUTH
+        elif lat == 0 and equator:
+            direction = "°"
+
+        if not poles and np.isclose(np.abs(lat), 90.0):
+            continue
+
+        value = int(abs(lat)) if direction else ""
+        result.append(f"{value}{direction}")
+
+    return result
+
+
+def create_parallels(
+    start: float | None = None,
+    stop: float | None = None,
+    step: float | None = None,
+    n_samples: int | None = None,
+    lon_step: float | None = None,
+    equator: bool | None = None,
+    poles: bool | None = None,
+    radius: float | None = None,
+    zlevel: float | ArrayLike | None = None,
+    zscale: float | None = None,
+    clean: bool | None = False,
+) -> GraticuleGrid:
+    """Generate graticule lines of latitude (parallels), with optional labels.
+
+    Parameters
+    ----------
+    * labels (bool):
+        Specify whether the graticule parallels are labelled. Default is ``True``.
+    * n_samples (None or float):
+        Specify the number of points contained within a graticule line of latitude.
+        Default is ``LATITUDE_N_SAMPLES``.
+    * step (None or float):
+        Specify the increment (in degrees) step size from the equator to the poles,
+        used to determine the graticule lines of latitude. The ``step`` is
+        modulo ``90`` degrees. Default is ``DEFAULT_LATITUDE_STEP``.
+    * lon_step (None or float):
+        Specify the increment (in degrees) step size from the prime meridian eastwards,
+        used to determine the longitude position of latitude labels. The ``lon_step`` is
+        modulo ``180`` degrees. Default is ``DEFAULT_LONGITUDE_STEP``.
+    * equator (bool):
+        Specify whether equatorial labels are to be rendered. Default is ``False``.
+    radius : float, optional
+        The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
+    zlevel : int, default=1
+        The z-axis level. Used in combination with the `zscale` to offset the
+        `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+    zscale : float, optional
+        The proportional multiplier for z-axis `zlevel`. Defaults to
+        :data:`geovista.common.ZLEVEL_SCALE`.
+
+    Returns
+    -------
+    PolyData
+
+
+    Notes
+    -----
+    .. versionadded:: 0.3.0
+
+    """
+    if start is None:
+        start = LATITUDE_START
+
+    if stop is None:
+        stop = LATITUDE_STOP
+
+    lat_step = LATITUDE_STEP if step is None else step
+
+    if n_samples is None:
+        n_samples = LATITUDE_N_SAMPLES
+
+    if lon_step is None:
+        lon_step = LONGITUDE_STEP
+
+    if equator is None:
+        equator = LATITUDE_LABEL_EQUATOR
+
+    if poles is None:
+        poles = LATITUDE_LABEL_POLES
+
+    if zlevel is None:
+        zlevel = 1
+
+    # step modulo sanity
+    lat_step %= 90.0
+    lon_step %= 180.0
+
+    lats = np.arange(start, stop + lat_step, lat_step, dtype=float)
+    lons = wrap(np.linspace(-180.0, 180.0, num=n_samples + 1)[:-1])
+
+    n_lines, n_segments = 0, 0
+    lines, grid_lats, points = [], [], []
+
+    for lat in lats:
+        if not poles and np.isclose(np.abs(lat), 90.0):
+            continue
+
+        xyz = to_cartesian(
+            lons,
+            np.ones_like(lons) * lat,
+            radius=radius,
+            zlevel=zlevel,
+            zscale=zscale,
+        )
+        n_points = xyz.shape[0]
+        points.append(xyz)
+        line = np.full((n_points, 3), 2, dtype=int)
+        line[:, 1] = np.arange(n_points) + n_segments
+        line[:, 2] = np.arange(n_points) + n_segments + 1
+        line[-1, 2] = n_segments
+        lines.append(line)
+        n_segments += n_points
+        n_lines += 1
+        grid_lats.append(lat)
+
+    points = np.vstack(points)
+    lines = np.vstack(lines)
+
+    mesh = pv.PolyData(points, lines=lines, n_lines=n_lines)
+    to_wkt(mesh, WGS84)
+
+    grid_points, grid_labels = [], []
+    labels = create_parallel_labels(grid_lats, equator=equator, poles=poles)
+    grid_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, lon_step, dtype=float)
+
+    for lon in grid_lons:
+        lonlat = np.vstack([np.ones_like(grid_lats, dtype=float) * lon, grid_lats]).T
+        grid_points.append(lonlat)
+        grid_labels.extend(labels)
+
+    if not poles:
+        lonlat = np.array([[0, 90], [0, -90]], dtype=float)
+        grid_points.append(lonlat)
+        pole_labels = create_parallel_labels([90, -90], poles=True)
+        grid_labels.extend(pole_labels)
+
+    if clean:
+        mesh.clean(inplace=True)
+
+    grid_points = np.vstack(grid_points)
+    graticule = GraticuleGrid(mesh=mesh, points=grid_points, labels=grid_labels)
+
+    return graticule

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -402,7 +402,7 @@ def create_parallels(
         ``poles_label``. Defaults to :data:`LATITUDE_POLES_PARALLEL`.
     poles_label : bool, optional
         Whether to create a single north/south pole label. Only applies when
-        ``poles=False``. Defaults to :data:`LATITUDE_POLES_LABEL`.
+        ``poles_parallel=False``. Defaults to :data:`LATITUDE_POLES_LABEL`.
     radius : float, optional
         The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
     zlevel : int, optional

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -259,7 +259,7 @@ def create_meridians(
 
     lons = np.arange(start, stop + lon_step, lon_step, dtype=float)
 
-    # TBD: require lon_0 to determine the wrap meridian
+    # TODO: require lon_0 to determine the wrap meridian
     if closed_interval:
         mask = np.isclose(lons, 180.0)
         lons = wrap(lons)
@@ -288,7 +288,7 @@ def create_meridians(
         mesh = pv.PolyData(xyz, lines=lines, n_lines=n_points)
         to_wkt(mesh, WGS84)
 
-        # TBD: require lon_0 to determine the wrap meridian
+        # TODO: require lon_0 to determine the wrap meridian
         if closed_interval and np.isclose(lon, 180.0):
             # mark this meridian as the closed interval wrap
             mask = np.empty(mesh.n_points, dtype=int)

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -289,7 +289,8 @@ def create_meridians(
             zlevel=zlevel,
             zscale=zscale,
         )
-        n_points = xyz.shape[0]
+        # a meridian with N points has N-1 lines
+        n_points = xyz.shape[0] - 1
         lines = np.full((n_points, 3), 2, dtype=int)
         lines[:, 1] = np.arange(n_points)
         lines[:, 2] = np.arange(n_points) + 1

--- a/src/geovista/qt.py
+++ b/src/geovista/qt.py
@@ -7,6 +7,8 @@ Notes
 .. versionadded:: 0.1.3
 
 """
+from __future__ import annotations
+
 try:
     import pyvistaqt as pvqt
 except ImportError as e:

--- a/src/geovista/theme.py
+++ b/src/geovista/theme.py
@@ -5,6 +5,8 @@ Notes
 .. versionadded:: 0.1.0
 
 """
+from __future__ import annotations
+
 import pyvista as pv
 
 theme = pv.themes.Theme()

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -94,13 +94,17 @@ def transform_mesh(
 
     if transform_required:
         # slice the mesh to break connectivity, but not for a point-cloud
-        if slice_connectivity and not cloud:
+        if slice_connectivity:
             if central_meridian:
                 mesh.rotate_z(-central_meridian, inplace=True)
                 tgt_crs = set_central_meridian(tgt_crs, 0)
 
-            # the sliced_mesh is guaranteed to be a new instance, even if not bisected
-            sliced_mesh = slice_mesh(mesh, rtol=rtol, atol=atol)
+            if not cloud:
+                # the sliced_mesh is guaranteed to be a new instance,
+                # even if not bisected
+                sliced_mesh = slice_mesh(mesh, rtol=rtol, atol=atol)
+            else:
+                sliced_mesh = mesh.copy()
 
             if central_meridian:
                 # undo rotation of original mesh
@@ -118,7 +122,7 @@ def transform_mesh(
         xs, ys = transformer.transform(xyz[:, 0], xyz[:, 1], errcheck=True)
         zs = 0
 
-        if not inplace and (cloud or not slice_connectivity):
+        if not inplace and not slice_connectivity:
             mesh = mesh.copy(deep=True)
 
         mesh.points[:, 0] = xs

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -128,7 +128,9 @@ def transform_mesh(
             xmin, xmax, ymin, ymax, _, _ = mesh.bounds
             xdelta, ydelta = abs(xmax - xmin), abs(ymax - ymin)
             # TODO: make this scale factor configurable at the API/module level
-            delta = min(xdelta, ydelta) // 4
+            # current strategy is slightly flawed in that there isn't consistent
+            # scaling across all geometries added to the render
+            delta = max(xdelta, ydelta) // 4
 
             if cloud:
                 zlevel += xyz[:, 2]

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -1,0 +1,143 @@
+"""Coordinate reference system (CRS) transformation functions.
+
+Notes
+-----
+.. versionadded:: 0.3.0
+
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+
+from numpy.typing import ArrayLike
+from pyproj import CRS, Transformer
+import pyvista as pv
+
+from .common import GV_FIELD_ZSCALE, ZLEVEL_SCALE, from_cartesian, point_cloud
+from .core import slice_mesh
+from .crs import WGS84, from_wkt, get_central_meridian, set_central_meridian, to_wkt
+
+__all__ = [
+    "transform_mesh",
+]
+
+
+def transform_mesh(
+    mesh: pv.PolyData,
+    tgt_crs: CRS,
+    slice_connectivity: bool | None = True,
+    rtol: float | None = None,
+    atol: float | None = None,
+    zlevel: float | ArrayLike | None = None,
+    zscale: float | None = None,
+    inplace: bool | None = False,
+) -> pv.PolyData:
+    """Transform the mesh from its source CRS to the target CRS.
+
+    Parameters
+    ----------
+    mesh : PolyData
+        The mesh to be transformed from its source coordinate reference system (CRS) to
+        the given `tgt_crs`.
+    tgt_crs : CRS
+        The target coordinate reference system (CRS) of the transformation.
+    slice_connectivity : bool, default=True
+        Slice the mesh prior to transformation in order to break mesh connectivity and
+        create a seam in the mesh. Also see :func:`geovista.core.slice_mesh`.
+    rtol : float, optional
+        The relative tolerance for values close to longitudinal
+        :func:`geovista.common.wrap` base + period.
+    atol : float, optional
+        The absolute tolerance for values close to longitudinal
+        :func:`geovista.common.wrap` base + period.
+    zlevel : int or ArrayLike, default=0
+        The z-axis level. Used in combination with the `zscale` to offset the
+        `radius`/vertical by a proportional amount e.g., ``radius * zlevel * zscale``.
+        If `zlevel` is not a scalar, then its shape must match or broadcast
+        with the shape of the ``mesh.points``.
+    zscale : float, optional
+        The proportional multiplier for z-axis `zlevel`. Defaults to
+        :data:`geovista.common.ZLEVEL_SCALE`.
+    inplace : bool, default=False
+        Update the `mesh` in-place. Can only perform an in-place operation when
+        ``slice_connectivity=False``
+
+    Returns
+    -------
+    PolyData
+        The mesh transformed to the target coordinate reference system (CRS).
+
+    Notes
+    -----
+    .. versionadded:: 0.3.0
+
+    """
+    src_crs = from_wkt(mesh)
+
+    if src_crs is None:
+        emsg = "Cannot transform mesh, no coordinate reference system (CRS) attached."
+        raise ValueError(emsg)
+
+    original_tgt_crs = deepcopy(tgt_crs)
+    transform_required = src_crs != tgt_crs
+    central_meridian = get_central_meridian(tgt_crs) or 0
+    cloud = point_cloud(mesh)
+
+    if zlevel is None:
+        zlevel = 0
+
+    if zscale is None:
+        if cloud and GV_FIELD_ZSCALE in mesh.field_data:
+            zscale = mesh[GV_FIELD_ZSCALE]
+        else:
+            zscale = ZLEVEL_SCALE
+
+    if transform_required:
+        # slice the mesh to break connectivity, but not for a point-cloud
+        if slice_connectivity and not cloud:
+            if central_meridian:
+                mesh.rotate_z(-central_meridian, inplace=True)
+                tgt_crs = set_central_meridian(tgt_crs, 0)
+
+            # the sliced_mesh is guaranteed to be a new instance, even if not bisected
+            sliced_mesh = slice_mesh(mesh, rtol=rtol, atol=atol)
+
+            if central_meridian:
+                # undo rotation of original mesh
+                mesh.rotate_z(central_meridian, inplace=True)
+
+            mesh = sliced_mesh
+
+        # now perform the CRS transformation
+        if src_crs == WGS84:
+            xyz = from_cartesian(mesh, closed_interval=True, rtol=rtol, atol=atol)
+        else:
+            xyz = mesh.points
+
+        transformer = Transformer.from_crs(src_crs, tgt_crs, always_xy=True)
+        xs, ys = transformer.transform(xyz[:, 0], xyz[:, 1], errcheck=True)
+        zs = 0
+
+        if not inplace and (cloud or not slice_connectivity):
+            mesh = mesh.copy(deep=True)
+
+        mesh.points[:, 0] = xs
+        mesh.points[:, 1] = ys
+
+        if zlevel or cloud:
+            xmin, xmax, ymin, ymax, _, _ = mesh.bounds
+            xdelta, ydelta = abs(xmax - xmin), abs(ymax - ymin)
+            # TODO: make this scale factor configurable at the API/module level
+            delta = min(xdelta, ydelta) // 4
+
+            if cloud:
+                zlevel += xyz[:, 2]
+
+            zs = zlevel * zscale * delta
+
+        mesh.points[:, 2] = zs
+
+        # TODO: check whether to clean other field_data metadata
+        to_wkt(mesh, original_tgt_crs)
+
+    return mesh

--- a/tests/bridge/test__as_compatible_data.py
+++ b/tests/bridge/test__as_compatible_data.py
@@ -1,4 +1,6 @@
 """Unit-tests for :meth:`geovista.Transform._as_compatible_data`."""
+from __future__ import annotations
+
 import numpy as np
 import numpy.ma as ma
 import pytest

--- a/tests/bridge/test_from_points.py
+++ b/tests/bridge/test_from_points.py
@@ -1,4 +1,6 @@
 """Unit-tests for :meth:`geovista.Transform.from_points`."""
+from __future__ import annotations
+
 import numpy as np
 from pyproj import CRS, Transformer
 import pytest

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -1,4 +1,5 @@
 """pytest fixture infra-structure for :mod:`geovista.common` unit-tests."""
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Union

--- a/tests/common/test_Preference.py
+++ b/tests/common/test_Preference.py
@@ -1,4 +1,6 @@
 """Unit-tests for :class:`geovista.common.Preference`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.common import Preference

--- a/tests/common/test_active_kernel.py
+++ b/tests/common/test_active_kernel.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.active_kernel`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.common import active_kernel

--- a/tests/common/test_distance.py
+++ b/tests/common/test_distance.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.distance`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/common/test_from_cartesian.py
+++ b/tests/common/test_from_cartesian.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.from_cartesian`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import pyvista as pv

--- a/tests/common/test_nan_mask.py
+++ b/tests/common/test_nan_mask.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.nan_mask`."""
+from __future__ import annotations
+
 import numpy as np
 import numpy.ma as ma
 import pytest

--- a/tests/common/test_point_cloud.py
+++ b/tests/common/test_point_cloud.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.point_cloud`."""
+from __future__ import annotations
+
 import pyvista as pv
 
 from geovista.common import point_cloud

--- a/tests/common/test_sanitize_data.py
+++ b/tests/common/test_sanitize_data.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.sanitize_data`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import pyvista as pv

--- a/tests/common/test_to_cartesian.py
+++ b/tests/common/test_to_cartesian.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.to_cartesian`."""
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import pytest

--- a/tests/common/test_to_lonlat.py
+++ b/tests/common/test_to_lonlat.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.to_lonlat`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/common/test_to_lonlats.py
+++ b/tests/common/test_to_lonlats.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.to_lonlats`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/common/test_triangulated.py
+++ b/tests/common/test_triangulated.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.triangulated`."""
+from __future__ import annotations
+
 from geovista.common import triangulated
 
 

--- a/tests/common/test_wrap.py
+++ b/tests/common/test_wrap.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.wrap`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 """pytest fixture infra-structure for :mod:`geovista.geodesic` unit-tests."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/core/test_add_texture_coords.py
+++ b/tests/core/test_add_texture_coords.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.core.add_texture_coords`."""
+from __future__ import annotations
+
 import pyvista as pv
 
 from geovista.common import point_cloud

--- a/tests/core/test_resize.py
+++ b/tests/core/test_resize.py
@@ -20,7 +20,7 @@ from geovista.core import resize
 def test_projection_fail():
     """Test trap of mesh that is not spherical."""
     mesh = pv.Plane()
-    emsg = "appears to be a planar projection"
+    emsg = "Cannot resize a mesh that has been projected"
     with pytest.raises(ValueError, match=emsg):
         _ = resize(mesh)
 

--- a/tests/core/test_resize.py
+++ b/tests/core/test_resize.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.core.resize`."""
+from __future__ import annotations
+
 import operator
 
 import numpy as np

--- a/tests/core/test_slice_cells.py
+++ b/tests/core/test_slice_cells.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.core.slice_cells`."""
+from __future__ import annotations
+
 import pytest
 import pyvista as pv
 

--- a/tests/core/test_slice_lines.py
+++ b/tests/core/test_slice_lines.py
@@ -46,11 +46,15 @@ def test_n_points_warning(coastlines, n_points):
         _ = slice_lines(coastlines, n_points=n_points)
 
 
+@pytest.mark.parametrize("copy", [False, True])
 @pytest.mark.parametrize("mesh", [line(0, [90, 0, -90]), line([-135, -45, 45, 135], 0)])
-def test_no_traversal_slice(mesh):
+def test_no_traversal_slice(copy, mesh):
     """Test a line mesh that does not traverse the antimeridian."""
-    result = slice_lines(mesh)
-    assert id(result) == id(mesh)
+    result = slice_lines(mesh, copy=copy)
+    if copy:
+        assert id(result) != id(mesh)
+    else:
+        assert id(result) == id(mesh)
     assert result == mesh
 
 

--- a/tests/core/test_slice_lines.py
+++ b/tests/core/test_slice_lines.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.common.slice_lines`."""
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import numpy as np

--- a/tests/core/test_slice_lines.py
+++ b/tests/core/test_slice_lines.py
@@ -32,10 +32,12 @@ def test_projected_fail(mesh):
 
 @pytest.mark.parametrize("mesh", [pv.Sphere(), lam_uk(), lfric()])
 def test_no_lines(mesh):
-    """Test trap of mesh with no lines."""
-    emsg = "Cannot slice a mesh containing no lines"
-    with pytest.raises(ValueError, match=emsg):
-        _ = slice_lines(mesh)
+    """Test nop slicing mesh with no lines."""
+    result = slice_lines(mesh)
+    assert id(result) == id(mesh)
+    assert result.n_cells == mesh.n_cells
+    assert result.n_lines == mesh.n_lines
+    assert result.n_points == mesh.n_points
 
 
 @pytest.mark.parametrize("n_points", [0, -1])

--- a/tests/core/test_slice_lines.py
+++ b/tests/core/test_slice_lines.py
@@ -20,8 +20,8 @@ class Kind:
     detach: int = 0
 
 
-# TBD: add further examples of geovista projected meshes,
-#      this requires "project_mesh" API support
+# TODO: add further examples of geovista projected meshes,
+#      this requires "transform_mesh" API support
 @pytest.mark.parametrize("mesh", [pv.Plane()])
 def test_projected_fail(mesh):
     """Test trap of a mesh that is projected."""

--- a/tests/crs/test_from_wkt.py
+++ b/tests/crs/test_from_wkt.py
@@ -1,4 +1,6 @@
 """Unit-test for :func:`geovista.crs.from_wkt`."""
+from __future__ import annotations
+
 import pyvista as pv
 
 from geovista.common import GV_FIELD_CRS

--- a/tests/crs/test_projected.py
+++ b/tests/crs/test_projected.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.crs.projected`."""
+from __future__ import annotations
+
 from pyproj import CRS
 import pyvista as pv
 

--- a/tests/crs/test_to_wkt.py
+++ b/tests/crs/test_to_wkt.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.crs.to_wkt`."""
+from __future__ import annotations
+
 import pyvista as pv
 
 from geovista.common import GV_FIELD_CRS

--- a/tests/geodesic/conftest.py
+++ b/tests/geodesic/conftest.py
@@ -1,4 +1,6 @@
 """pytest fixture infra-structure for :mod:`geovista.geodesic` unit-tests."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.common import from_cartesian

--- a/tests/geodesic/test_BBox.py
+++ b/tests/geodesic/test_BBox.py
@@ -1,4 +1,6 @@
 """Unit-tests for :class:`geovista.geodesic.BBox`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/geodesic/test_Preference.py
+++ b/tests/geodesic/test_Preference.py
@@ -1,4 +1,6 @@
 """Unit-tests for :class:`geovista.geodesic.Preference`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.geodesic import Preference

--- a/tests/geodesic/test_line.py
+++ b/tests/geodesic/test_line.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.geodesic.line`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/geometry/conftest.py
+++ b/tests/geometry/conftest.py
@@ -1,4 +1,5 @@
 """pytest fixture infra-structure for :mod:`geovista.geometry` unit-tests."""
+from __future__ import annotations
 
 import pytest
 

--- a/tests/geometry/test_coastlines.py
+++ b/tests/geometry/test_coastlines.py
@@ -1,4 +1,6 @@
 """Unit-test for :func:`geovista.geometry.coastlines`."""
+from __future__ import annotations
+
 from geovista.common import COASTLINES_RESOLUTION
 from geovista.geometry import coastlines
 

--- a/tests/geometry/test_load_coastline_geometries.py
+++ b/tests/geometry/test_load_coastline_geometries.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.geometry.test_load_coastline_geometries`."""
+from __future__ import annotations
+
 import numpy as np
 
 from geovista.common import COASTLINES_RESOLUTION

--- a/tests/geometry/test_load_coastlines.py
+++ b/tests/geometry/test_load_coastlines.py
@@ -1,4 +1,6 @@
 """Unit-test for :func:`geovista.geometry.load_coastlines`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/gridlines/__init__.py
+++ b/tests/gridlines/__init__.py
@@ -1,0 +1,1 @@
+"""Unit-tests for :mod:`geovista.gridlines`."""

--- a/tests/gridlines/conftest.py
+++ b/tests/gridlines/conftest.py
@@ -1,4 +1,5 @@
 """pytest fixture infra-structure for :mod:`geovista.gridlines` unit-tests."""
+from __future__ import annotations
 
 
 def deindex(keys: list[str, ...] | str) -> list[str, ...] | str:

--- a/tests/gridlines/conftest.py
+++ b/tests/gridlines/conftest.py
@@ -1,0 +1,10 @@
+"""pytest fixture infra-structure for :mod:`geovista.gridlines` unit-tests."""
+
+
+def deindex(keys: list[str, ...] | str) -> list[str, ...] | str:
+    """Remove the index from the GraticuleGrid.blocks.keys()."""
+    if isinstance(keys, str):
+        result = keys.split(",")[1]
+    else:
+        result = [key.split(",")[1] for key in keys]
+    return result

--- a/tests/gridlines/test__step_period.py
+++ b/tests/gridlines/test__step_period.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.gridlines._step_period`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/gridlines/test__step_period.py
+++ b/tests/gridlines/test__step_period.py
@@ -1,0 +1,40 @@
+"""Unit-tests for :func:`geovista.gridlines._step_period`."""
+import numpy as np
+import pytest
+
+from geovista.gridlines import LATITUDE_STEP_PERIOD, LONGITUDE_STEP_PERIOD
+from geovista.gridlines import _step_period as step_period
+
+
+def expected(value: float, period: float) -> tuple[float, float]:
+    """Calculate expected value within period."""
+    count = abs(value) // period
+    if value >= 0:
+        result = value - (count * period)
+    else:
+        result = value + (count * period)
+
+    return result
+
+
+@pytest.mark.parametrize(
+    "lon, lat",
+    [
+        [0, 0],
+        [LONGITUDE_STEP_PERIOD // 2, LATITUDE_STEP_PERIOD // 2],
+        [LONGITUDE_STEP_PERIOD, LATITUDE_STEP_PERIOD],
+        [LONGITUDE_STEP_PERIOD * 1.5, LATITUDE_STEP_PERIOD * 1.5],
+        [-LONGITUDE_STEP_PERIOD // 2, -LATITUDE_STEP_PERIOD // 2],
+        [-LONGITUDE_STEP_PERIOD, -LATITUDE_STEP_PERIOD],
+        [-LONGITUDE_STEP_PERIOD * 1.5, -LATITUDE_STEP_PERIOD * 1.5],
+    ],
+)
+def test(lon, lat):
+    """Test enforced sane upper bounds on graticule lon/lat step size."""
+    alon, alat = step_period(lon, lat)
+    elon = expected(lon, LONGITUDE_STEP_PERIOD)
+    elat = expected(lat, LATITUDE_STEP_PERIOD)
+    assert alon < LONGITUDE_STEP_PERIOD
+    assert np.isclose(alon, elon)
+    assert alat < LATITUDE_STEP_PERIOD
+    assert np.isclose(alat, elat)

--- a/tests/gridlines/test_create_meridian_labels.py
+++ b/tests/gridlines/test_create_meridian_labels.py
@@ -1,0 +1,52 @@
+"""Unit-tests for :func:`geovista.gridlines.create_meridian_labels`."""
+import pytest
+
+from geovista.gridlines import (
+    LABEL_DEGREE,
+    LABEL_EAST,
+    LABEL_WEST,
+    create_meridian_labels,
+)
+
+
+def test_empty():
+    """Test nop label generation."""
+    result = create_meridian_labels([])
+    assert len(result) == 0
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        [-180, f"180{LABEL_DEGREE}"],
+        [[-180], f"180{LABEL_DEGREE}"],
+        [-90, f"90{LABEL_WEST}"],
+        [[-90], f"90{LABEL_WEST}"],
+        [0, f"0{LABEL_DEGREE}"],
+        [[0], f"0{LABEL_DEGREE}"],
+        [90, f"90{LABEL_EAST}"],
+        [[90], f"90{LABEL_EAST}"],
+        [180, f"180{LABEL_DEGREE}"],
+        [[180], f"180{LABEL_DEGREE}"],
+    ],
+)
+def test(value, expected):
+    """Test label generation of a meridian."""
+    result = create_meridian_labels(value)
+    assert result == [expected]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        [-180.1, f"180{LABEL_DEGREE}"],
+        [-90.12, f"90{LABEL_WEST}"],
+        [0.123, f"0{LABEL_DEGREE}"],
+        [90.1234, f"90{LABEL_EAST}"],
+        [180.12345, f"180{LABEL_DEGREE}"],
+    ],
+)
+def test_truncation(value, expected):
+    """Test label generation performs value truncation."""
+    result = create_meridian_labels(value)
+    assert result == [expected]

--- a/tests/gridlines/test_create_meridian_labels.py
+++ b/tests/gridlines/test_create_meridian_labels.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.gridlines.create_meridian_labels`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.gridlines import (

--- a/tests/gridlines/test_create_meridians.py
+++ b/tests/gridlines/test_create_meridians.py
@@ -1,0 +1,126 @@
+"""Unit-tests for :func:`geovista.gridlines.create_meridians`."""
+import numpy as np
+import pytest
+
+from geovista.common import (
+    GV_FIELD_CRS,
+    GV_REMESH_POINT_IDS,
+    RADIUS,
+    REMESH_SEAM,
+    ZLEVEL_SCALE,
+    distance,
+    from_cartesian,
+)
+from geovista.crs import WGS84, from_wkt
+from geovista.gridlines import (
+    GRATICULE_ZLEVEL,
+    LATITUDE_START,
+    LATITUDE_STEP,
+    LATITUDE_STOP,
+    LONGITUDE_N_SAMPLES,
+    LONGITUDE_START,
+    LONGITUDE_STEP,
+    LONGITUDE_STOP,
+    create_meridian_labels,
+    create_meridians,
+)
+
+
+@pytest.mark.parametrize("step", [-1, 0])
+def test_step_fail(step):
+    """Test trap of invalid step value."""
+    emsg = "Require a non-zero positive value"
+    with pytest.raises(ValueError, match=emsg):
+        _ = create_meridians(step=step)
+
+
+@pytest.mark.parametrize("lat_step", [-1, 0])
+def test_lat_step_fail(lat_step):
+    """Test trap of invalid latitude step value."""
+    emsg = "Require a non-zero positive value"
+    with pytest.raises(ValueError, match=emsg):
+        _ = create_meridians(lat_step=lat_step)
+
+
+@pytest.mark.parametrize(
+    "n_samples",
+    [LONGITUDE_N_SAMPLES // 2, LONGITUDE_N_SAMPLES, 2 * LONGITUDE_N_SAMPLES],
+)
+@pytest.mark.parametrize("zlevel", [None, 1, 10])
+@pytest.mark.parametrize("step", [None, 15, 30])
+def test_core(n_samples, zlevel, step):
+    """Test core behaviour of meridian generation."""
+    result = create_meridians(step=step, n_samples=n_samples, zlevel=zlevel)
+    if step is None:
+        step = LONGITUDE_STEP
+    meridian_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, step)
+    meridians = [str(lon) for lon in meridian_lons]
+    # check the meridian longitudes
+    assert result.blocks.keys() == meridians
+    # check the meridian meshes (blocks)
+    for meridian in meridians:
+        mesh = result.blocks[meridian]
+        assert mesh.n_points == n_samples
+        assert mesh.n_cells == (n_lines := n_samples - 1)
+        assert mesh.n_lines == n_lines
+        lonlat = from_cartesian(mesh)
+        lons = np.unique(lonlat[:, 0])
+        assert lons.size == 1
+        assert np.isclose(lons, float(meridian))
+        if zlevel is None:
+            zlevel = GRATICULE_ZLEVEL
+        expected_radius = RADIUS + (RADIUS * ZLEVEL_SCALE * zlevel)
+        assert np.isclose(distance(mesh, mean=True), expected_radius)
+        assert GV_FIELD_CRS in mesh.field_data
+        assert from_wkt(mesh) == WGS84
+    # check the meridian label points (lonlat)
+    label_lats = np.arange(LATITUDE_START, LATITUDE_STOP, LATITUDE_STEP) + (
+        LATITUDE_STEP / 2
+    )
+    n_lons, n_lats = meridian_lons.size, label_lats.size
+    assert result.lonlat.shape == (n_lons * n_lats, 2)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 0]), meridian_lons)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 1]), label_lats)
+    # check the meridian labels (labels)
+    actual_labels = np.unique(result.labels)
+    expected_labels = create_meridian_labels(list(meridian_lons))
+    np.testing.assert_array_equal(actual_labels, np.sort(expected_labels))
+
+
+@pytest.mark.parametrize("lat_step", [None, 15, 30])
+def test_lat_step(lat_step):
+    """Test meridian label generation over different lat_step's."""
+    result = create_meridians(lat_step=lat_step)
+    if lat_step is None:
+        lat_step = LATITUDE_STEP
+    meridian_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, LONGITUDE_STEP)
+    # check the meridian label points (lonlat)
+    label_lats = np.arange(LATITUDE_START, LATITUDE_STOP, lat_step) + (lat_step / 2)
+    n_lons, n_lats = meridian_lons.size, label_lats.size
+    assert result.lonlat.shape == (n_lons * n_lats, 2)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 0]), meridian_lons)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 1]), label_lats)
+    # check the meridian labels (labels)
+    actual_labels = np.unique(result.labels)
+    expected_labels = create_meridian_labels(list(meridian_lons))
+    np.testing.assert_array_equal(actual_labels, np.sort(expected_labels))
+
+
+def test_closed_interval():
+    """Test the treatment of meridian closed intervals."""
+    result = create_meridians(closed_interval=True)
+    meridian_lons = np.arange(
+        LONGITUDE_START, LONGITUDE_STOP + LONGITUDE_STEP, LONGITUDE_STEP
+    )
+    meridians = [str(lon) for lon in meridian_lons]
+    # check the meridian longitudes
+    assert result.blocks.keys() == meridians
+    boundary = str(float(180))
+    assert boundary in result.blocks.keys()
+    for meridian in meridians:
+        mesh = result.blocks[meridian]
+        if meridian == boundary:
+            assert GV_REMESH_POINT_IDS in mesh.point_data
+            assert np.isclose(np.unique(mesh[GV_REMESH_POINT_IDS]), REMESH_SEAM)
+        else:
+            assert GV_REMESH_POINT_IDS not in mesh.point_data

--- a/tests/gridlines/test_create_meridians.py
+++ b/tests/gridlines/test_create_meridians.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.gridlines.create_meridians`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/gridlines/test_create_meridians.py
+++ b/tests/gridlines/test_create_meridians.py
@@ -70,7 +70,7 @@ def test_core(n_samples, zlevel, step):
         if zlevel is None:
             zlevel = GRATICULE_ZLEVEL
         expected_radius = RADIUS + (RADIUS * ZLEVEL_SCALE * zlevel)
-        assert np.isclose(distance(mesh, mean=True), expected_radius)
+        assert np.isclose(distance(mesh), expected_radius)
         assert GV_FIELD_CRS in mesh.field_data
         assert from_wkt(mesh) == WGS84
     # check the meridian label points (lonlat)
@@ -87,7 +87,7 @@ def test_core(n_samples, zlevel, step):
     np.testing.assert_array_equal(actual_labels, np.sort(expected_labels))
 
 
-@pytest.mark.parametrize("lat_step", [None, 15, 30])
+@pytest.mark.parametrize("lat_step", [None, 15, 30, 60])
 def test_lat_step(lat_step):
     """Test meridian label generation over different lat_step's."""
     result = create_meridians(lat_step=lat_step)

--- a/tests/gridlines/test_create_parallel_labels.py
+++ b/tests/gridlines/test_create_parallel_labels.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.gridlines.create_parallel_labels`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.gridlines import (

--- a/tests/gridlines/test_create_parallel_labels.py
+++ b/tests/gridlines/test_create_parallel_labels.py
@@ -1,0 +1,69 @@
+"""Unit-tests for :func:`geovista.gridlines.create_parallel_labels`."""
+import pytest
+
+from geovista.gridlines import (
+    LABEL_DEGREE,
+    LABEL_NORTH,
+    LABEL_SOUTH,
+    create_parallel_labels,
+)
+
+
+def test_empty():
+    """Test nop label generation."""
+    result = create_parallel_labels([])
+    assert len(result) == 0
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        [-90, f"90{LABEL_SOUTH}"],
+        [[-90], f"90{LABEL_SOUTH}"],
+        [-45, f"45{LABEL_SOUTH}"],
+        [[-45], f"45{LABEL_SOUTH}"],
+        [0, f"0{LABEL_DEGREE}"],
+        [[0], f"0{LABEL_DEGREE}"],
+        [45, f"45{LABEL_NORTH}"],
+        [[45], f"45{LABEL_NORTH}"],
+        [90, f"90{LABEL_NORTH}"],
+        [[90], f"90{LABEL_NORTH}"],
+    ],
+)
+def test(value, expected):
+    """Test label generation of a parallel."""
+    result = create_parallel_labels(value, poles_parallel=True)
+    assert result == [expected]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        [-90, None],
+        [-45, f"45{LABEL_SOUTH}"],
+        [0, f"0{LABEL_DEGREE}"],
+        [45, f"45{LABEL_NORTH}"],
+        [90, None],
+    ],
+)
+def test_default_poles_parallel(value, expected):
+    """Test label generation of a parallel, excluding poles by default."""
+    result = create_parallel_labels(value)
+    expected = [] if expected is None else [expected]
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        [-90.1, f"90{LABEL_SOUTH}"],
+        [-45.12, f"45{LABEL_SOUTH}"],
+        [0.123, f"0{LABEL_DEGREE}"],
+        [45.1234, f"45{LABEL_NORTH}"],
+        [90.12345, f"90{LABEL_NORTH}"],
+    ],
+)
+def test_truncation(value, expected):
+    """Test label generation performs value truncation."""
+    result = create_parallel_labels(value, poles_parallel=True)
+    assert result == [expected]

--- a/tests/gridlines/test_create_parallels.py
+++ b/tests/gridlines/test_create_parallels.py
@@ -1,0 +1,155 @@
+"""Unit-tests for :func:`geovista.gridlines.create_parallels`."""
+import numpy as np
+import pytest
+
+from geovista.common import (
+    GV_FIELD_CRS,
+    RADIUS,
+    ZLEVEL_SCALE,
+    distance,
+    from_cartesian,
+)
+from geovista.crs import WGS84, from_wkt
+from geovista.gridlines import (
+    GRATICULE_ZLEVEL,
+    LATITUDE_N_SAMPLES,
+    LATITUDE_START,
+    LATITUDE_STEP,
+    LATITUDE_STOP,
+    LONGITUDE_START,
+    LONGITUDE_STEP,
+    LONGITUDE_STOP,
+    create_parallel_labels,
+    create_parallels,
+)
+
+
+@pytest.mark.parametrize("step", [-1, 0])
+def test_step_fail(step):
+    """Test trap of invalid step value."""
+    emsg = "Require a non-zero positive value"
+    with pytest.raises(ValueError, match=emsg):
+        _ = create_parallels(step=step)
+
+
+@pytest.mark.parametrize("lon_step", [-1, 0])
+def test_lon_step_fail(lon_step):
+    """Test trap of invalid longitude step value."""
+    emsg = "Require a non-zero positive value"
+    with pytest.raises(ValueError, match=emsg):
+        _ = create_parallels(lon_step=lon_step)
+
+
+@pytest.mark.parametrize(
+    "n_samples", [LATITUDE_N_SAMPLES // 2, LATITUDE_N_SAMPLES, 2 * LATITUDE_N_SAMPLES]
+)
+@pytest.mark.parametrize("zlevel", [None, 1, 10])
+@pytest.mark.parametrize("poles_label", [False, True])
+def test_core(n_samples, zlevel, poles_label):
+    """Test core behaviour of parallel generation."""
+    result = create_parallels(
+        n_samples=n_samples, poles_label=poles_label, zlevel=zlevel
+    )
+    # purge the poles by default
+    parallel_lats = np.arange(
+        LATITUDE_START, LATITUDE_STOP + LATITUDE_STEP, LATITUDE_STEP
+    )[1:-1]
+    parallels = [str(lat) for lat in parallel_lats]
+    # check the parallel latitudes
+    assert result.blocks.keys() == parallels
+    # check the parallel meshes (blocks)
+    for parallel in parallels:
+        mesh = result.blocks[parallel]
+        assert mesh.n_points == n_samples
+        assert mesh.n_cells == n_samples
+        assert mesh.n_lines == n_samples
+        lonlat = from_cartesian(mesh)
+        lats = np.unique(lonlat[:, 1])
+        assert lats.size == 1
+        assert np.isclose(lats, float(parallel))
+        if zlevel is None:
+            zlevel = GRATICULE_ZLEVEL
+        expected_radius = RADIUS + (RADIUS * ZLEVEL_SCALE * zlevel)
+        assert np.isclose(distance(mesh), expected_radius)
+        assert GV_FIELD_CRS in mesh.field_data
+        assert from_wkt(mesh) == WGS84
+    # check the parallel label points (lonlat)
+    label_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, LONGITUDE_STEP) + (
+        LONGITUDE_STEP / 2
+    )
+    n_lons, n_lats = label_lons.size, parallel_lats.size
+    n_points = n_lons * n_lats
+    if poles_label:
+        label_lons = np.sort(np.concatenate([label_lons, [0]]))
+        parallel_lats = np.sort(np.concatenate([parallel_lats, [90.0, -90]]))
+        n_points += 2
+    assert result.lonlat.shape == (n_points, 2)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 0]), label_lons)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 1]), parallel_lats)
+    # check the parallel labels (labels)
+    actual_labels = np.unique(result.labels)
+    expected_labels = create_parallel_labels(list(parallel_lats), poles_parallel=True)
+    np.testing.assert_array_equal(actual_labels, np.sort(expected_labels))
+
+
+@pytest.mark.parametrize("lon_step", [None, 15, 30, 60])
+def test_lon_step(lon_step):
+    """Test parallel label generation over different lon_step's."""
+    result = create_parallels(lon_step=lon_step)
+    if lon_step is None:
+        lon_step = LONGITUDE_STEP
+    parallel_lats = np.arange(
+        LATITUDE_START, LATITUDE_STOP + LATITUDE_STEP, LATITUDE_STEP
+    )[1:-1]
+    # check the parallel label points (lonlat)
+    label_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, lon_step) + (lon_step / 2)
+    n_lons, n_lats = label_lons.size, parallel_lats.size
+    n_points = n_lons * n_lats
+    # assumes poles_label=True by default
+    label_lons = np.sort(np.concatenate([label_lons, [0]]))
+    parallel_lats = np.sort(np.concatenate([parallel_lats, [90.0, -90]]))
+    n_points += 2
+    assert result.lonlat.shape == (n_points, 2)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 0]), label_lons)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 1]), parallel_lats)
+    # check the parallel labels (labels)
+    actual_labels = np.unique(result.labels)
+    expected_labels = create_parallel_labels(list(parallel_lats), poles_parallel=True)
+    np.testing.assert_array_equal(actual_labels, np.sort(expected_labels))
+
+
+def test_poles_parallel():
+    """Test parallel generation including poles."""
+    result = create_parallels(poles_parallel=True)
+    # retain the poles
+    parallel_lats = np.arange(
+        LATITUDE_START, LATITUDE_STOP + LATITUDE_STEP, LATITUDE_STEP
+    )
+    parallels = [str(lat) for lat in parallel_lats]
+    # check the parallel latitudes
+    assert result.blocks.keys() == parallels
+    # check the parallel meshes (blocks)
+    for parallel in parallels:
+        mesh = result.blocks[parallel]
+        assert mesh.n_points == LATITUDE_N_SAMPLES
+        assert mesh.n_cells == LATITUDE_N_SAMPLES
+        assert mesh.n_lines == LATITUDE_N_SAMPLES
+        lonlat = from_cartesian(mesh)
+        lats = np.unique(lonlat[:, 1])
+        assert lats.size == 1
+        assert np.isclose(lats, float(parallel))
+        assert GV_FIELD_CRS in mesh.field_data
+        assert from_wkt(mesh) == WGS84
+    # check the parallel label points (lonlat)
+    label_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, LONGITUDE_STEP) + (
+        LONGITUDE_STEP / 2
+    )
+    n_lons, n_lats = label_lons.size, parallel_lats.size
+    n_points = n_lons * n_lats
+    assert result.lonlat.shape == (n_points, 2)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 0]), label_lons)
+    np.testing.assert_array_equal(np.unique(result.lonlat[:, 1]), parallel_lats)
+    # # check the parallel labels (labels)
+    actual_labels = np.unique(result.labels)
+    expected_labels = create_parallel_labels(list(parallel_lats), poles_parallel=True)
+    np.testing.assert_array_equal(actual_labels, np.sort(expected_labels))

--- a/tests/gridlines/test_create_parallels.py
+++ b/tests/gridlines/test_create_parallels.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.gridlines.create_parallels`."""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/gridlines/test_create_parallels.py
+++ b/tests/gridlines/test_create_parallels.py
@@ -23,6 +23,8 @@ from geovista.gridlines import (
     create_parallels,
 )
 
+from .conftest import deindex
+
 
 @pytest.mark.parametrize("step", [-1, 0])
 def test_step_fail(step):
@@ -56,17 +58,18 @@ def test_core(n_samples, zlevel, poles_label):
     )[1:-1]
     parallels = [str(lat) for lat in parallel_lats]
     # check the parallel latitudes
-    assert result.blocks.keys() == parallels
+    blocks_parallels = deindex(result.blocks.keys())
+    assert blocks_parallels == parallels
     # check the parallel meshes (blocks)
-    for parallel in parallels:
-        mesh = result.blocks[parallel]
+    for key in result.blocks.keys():
+        mesh = result.blocks[key]
         assert mesh.n_points == n_samples
         assert mesh.n_cells == n_samples
         assert mesh.n_lines == n_samples
         lonlat = from_cartesian(mesh)
         lats = np.unique(lonlat[:, 1])
         assert lats.size == 1
-        assert np.isclose(lats, float(parallel))
+        assert np.isclose(lats, float(deindex(key)))
         if zlevel is None:
             zlevel = GRATICULE_ZLEVEL
         expected_radius = RADIUS + (RADIUS * ZLEVEL_SCALE * zlevel)
@@ -127,20 +130,21 @@ def test_poles_parallel():
     )
     parallels = [str(lat) for lat in parallel_lats]
     # check the parallel latitudes
-    assert result.blocks.keys() == parallels
+    blocks_parallels = deindex(result.blocks.keys())
+    assert blocks_parallels == parallels
     # check the parallel meshes (blocks)
-    for parallel in parallels:
-        mesh = result.blocks[parallel]
+    for key in result.blocks.keys():
+        mesh = result.blocks[key]
         assert mesh.n_points == LATITUDE_N_SAMPLES
         assert mesh.n_cells == LATITUDE_N_SAMPLES
         assert mesh.n_lines == LATITUDE_N_SAMPLES
         lonlat = from_cartesian(mesh)
         lats = np.unique(lonlat[:, 1])
         assert lats.size == 1
-        assert np.isclose(lats, float(parallel))
+        assert np.isclose(lats, float(deindex(key)))
         assert GV_FIELD_CRS in mesh.field_data
         assert from_wkt(mesh) == WGS84
-    # check the parallel label points (lonlat)
+    # # check the parallel label points (lonlat)
     label_lons = np.arange(LONGITUDE_START, LONGITUDE_STOP, LONGITUDE_STEP) + (
         LONGITUDE_STEP / 2
     )

--- a/tests/samples/test_fvcom_tamar.py
+++ b/tests/samples/test_fvcom_tamar.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.samples.fvcom_tamar`."""
+from __future__ import annotations
+
 import operator
 
 import numpy as np

--- a/tests/search/conftest.py
+++ b/tests/search/conftest.py
@@ -1,4 +1,6 @@
 """pytest fixture infra-structure for :mod:`geovista.search` unit-tests."""
+from __future__ import annotations
+
 from collections import namedtuple
 
 import pytest

--- a/tests/search/test_KDTree.py
+++ b/tests/search/test_KDTree.py
@@ -1,4 +1,6 @@
 """Unit-tests for :class:`geovista.search.KDTree`."""
+from __future__ import annotations
+
 import numpy as np
 from pyproj import CRS, Transformer
 import pytest

--- a/tests/search/test_Preference.py
+++ b/tests/search/test_Preference.py
@@ -1,4 +1,6 @@
 """Unit-tests for :class:`geovista.search.Preference`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.search import Preference

--- a/tests/search/test_find_cell_neighbours.py
+++ b/tests/search/test_find_cell_neighbours.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.search.find_cell_neighbours`."""
+from __future__ import annotations
+
 from geovista.search import find_cell_neighbours
 
 

--- a/tests/search/test_find_nearest_cell.py
+++ b/tests/search/test_find_nearest_cell.py
@@ -1,4 +1,6 @@
 """Unit-tests for :func:`geovista.search.find_nearest_cell`."""
+from __future__ import annotations
+
 import pytest
 
 from geovista.common import from_cartesian, to_lonlat

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -1,4 +1,6 @@
 """Unit-tests for :mod:`geovista.qt`."""
+from __future__ import annotations
+
 import pytest
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR slightly unraveled. Various past sins and connective tissue tech debt required to be addressed to get this PR across the line. Sometimes, life if like that.

As a result, `geovista` is tending towards a "much better place".

The purpose of this PR is to provide initial graticule support for both spherical and projected geometries. In doing so, the following necessary steps were also taken:

- unfolding polar end-points of lines
- rationalising line and cell slicing
- refactoring `geovista.geoplotter.GeoPlotterBase` to expose mesh projecting at an API level through `geovista.transform.transform_mesh`
- extending the `geovista.geoplotter.GeoPlotterBase` API to support graticules, meridians and parallels
- the creation of `geovista.gridlines` module

The following new methods, functions and modules have been created:

- `geovista.core.slice_mesh` (new `function`)
- `geovista.geoplotter.GeoPlotterBase`
  - `_add_graticule_labels` (new `method`)
  - `add_graticule` (new `method`)
  - `add_meridian` (new `method`)
  - `add_meridians` (new `method`)
  - `add_parallel` (new `method`)
  - `add_parallels` (new `method`)
- `geovista.transform` (new `module`)
  - `transform_mesh` (new `function`)
- `geovista.gridlines` (new `module`)
  - `create_meridian_labels` (new `function`)
  - `create_meridians` (new `function`)
  - `create_parallel_labels` (new `function`)
  - `create_parallels` (new `function`)

---
