### PR TITLE
remove explicit vtk dependency

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -85,6 +85,8 @@ jobs:
         cache_build: 0
 
     - name: "lock (${{ matrix.version }})"
+      env:
+        VTK_BUILD: "  - vtk=*=qt_*"
       run: |
         tox -e ${{ matrix.version }}-lock
 

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -19,7 +19,6 @@ dependencies:
   - pykdtree
   - pyproj >=3.3
   - pyvista >=0.40
-  - vtk >=9.2.6
 
 # pantry dependencies
   - netcdf4

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -9,4 +9,3 @@ pooch
 pykdtree
 pyproj>=3.3
 pyvista>=0.40
-vtk>=9.2.6

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ skip_install =
 commands =
     # inject python version pin to yaml
     cp {env:YAML} {env:WORK}
-    python -c 'from sys import version_info as v; open("{env:WORK}", "a").write(f"\n  - python =\{v.major\}.\{v.minor\}\n")'
+    python -c 'from sys import version_info as v; open("{env:WORK}", "a").write(f"\n  - python =\{v.major\}.\{v.minor\}\n{env:VTK_BUILD:}")'
     # resolve the dependencies
     conda-lock --mamba --channel conda-forge --kind explicit --file {env:WORK} --platform linux-64 --filename-template "{envname}-\{platform\}.txt"
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR removes the explicit `vtk` package dependency from `geovista`, to instead defer and rely on the management of which flavour of `vtk` is installed by `pyvista` and/or the user.

By not pinning to a specific version of `vtk` within `geovista`, users now have he ability to chose the version of `vtk` that they specifically require given their specific workflow and environment/platform requirements.

However, for the generation of `geovista` development `conda` lock-files, we are opinionated and "inject" the requirement of the `qt` build for `vtk`. Otherwise, whilst `conda-lock` resolves the `geovista` recipe on a GH runner, the headless `osmesa` build variant is chosen, which is not what we want; causing CI test carnage.

Closes #376

---
