### PR TITLE
fix typing ellipsis usage

### DIFF
--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -755,10 +755,10 @@ def slice_lines(
     cid_xyz_1d = np.concatenate([mesh.points[pids] for pids in cid_pids])
 
     # use explicit typing for clarity ...
-    split_cids: list[int, ...] = []
-    split_xyz: list[ArrayLike, ...] = []
+    split_cids: list[int] = []
+    split_xyz: list[ArrayLike] = []
     detach_cids: list[int] = []
-    detach_pids: list[int, ...] = []
+    detach_pids: list[int] = []
 
     for xyz, cid in zip(poi_xyz, poi_cids):
         mask = np.all(np.isclose(cid_xyz_1d, xyz), axis=1)

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -103,7 +103,7 @@ class GraticuleGrid:
 
     blocks: pv.MultiBlock
     lonlat: ArrayLike
-    labels: list[str, ...]
+    labels: list[str]
     mask: ArrayLike = None
 
 
@@ -138,7 +138,7 @@ def _step_period(lon: float, lat: float) -> tuple[float, float]:
     return (lon, lat)
 
 
-def create_meridian_labels(lons: list[float, ...]) -> list[str, ...]:
+def create_meridian_labels(lons: list[float]) -> list[str]:
     """Generate labels for the meridians.
 
     Parameters
@@ -339,8 +339,8 @@ def create_meridians(
 
 
 def create_parallel_labels(
-    lats: list[float, ...], poles_parallel: bool | None = None
-) -> list[str, ...]:
+    lats: list[float], poles_parallel: bool | None = None
+) -> list[str]:
     """Generate labels for the parallels.
 
     Parameters

--- a/src/geovista/samples.py
+++ b/src/geovista/samples.py
@@ -52,7 +52,7 @@ __all__ = [
 LFRIC_RESOLUTION: str = "c96"
 
 #: The available Met Office cubed-sphere assets.
-LFRIC_RESOLUTIONS: list[str, ...] = ["c48", "c96", "c192"]
+LFRIC_RESOLUTIONS: list[str] = ["c48", "c96", "c192"]
 
 #: The default mesh preference.
 PREFERENCE: Preference = Preference.CELL


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The ellipsis usage only applies to a tuple e.g., `tuple[int, ...]` and not `list`.

---
