### PR TITLE
add transform point and points

### DIFF
--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -11,13 +11,12 @@ Notes
 """
 from __future__ import annotations
 
-from typing import Union
 import warnings
 
 import numpy as np
 from numpy import ma
 from numpy.typing import ArrayLike
-from pyproj import CRS, Transformer
+from pyproj import CRS
 import pyvista as pv
 
 from .common import (
@@ -30,13 +29,13 @@ from .common import (
     to_cartesian,
     wrap,
 )
-from .crs import WGS84, to_wkt
+from .crs import WGS84, CRSLike, to_wkt
+from .transform import transform_points
 
 __all__ = ["Transform"]
 
 # type aliases
 Shape = tuple[int]
-CRSLike = Union[int, str, dict, CRS]
 
 #: Whether mesh cleaning performed by the bridge.
 BRIDGE_CLEAN: bool = False
@@ -593,8 +592,8 @@ class Transform:
             crs = CRS.from_user_input(crs)
 
             if crs != WGS84:
-                transformer = Transformer.from_crs(crs, WGS84, always_xy=True)
-                xs, ys = transformer.transform(xs, ys, errcheck=True)
+                transformed = transform_points(src_crs=crs, tgt_crs=WGS84, xs=xs, ys=ys)
+                xs, ys = transformed[:, 0], transformed[:, 1]
 
         # ensure longitudes (degrees) are in half-closed interval [-180, 180)
         xs = wrap(xs)
@@ -745,8 +744,8 @@ class Transform:
             crs = CRS.from_user_input(crs)
 
             if crs != WGS84:
-                transformer = Transformer.from_crs(crs, WGS84, always_xy=True)
-                xs, ys = transformer.transform(xs, ys, errcheck=True)
+                transformed = transform_points(src_crs=crs, tgt_crs=WGS84, xs=xs, ys=ys)
+                xs, ys = transformed[:, 0], transformed[:, 1]
 
         # ensure longitudes (degrees) are in half-closed interval [-180, 180)
         xs = wrap(xs)

--- a/src/geovista/crs.py
+++ b/src/geovista/crs.py
@@ -7,6 +7,8 @@ Notes
 """
 from __future__ import annotations
 
+from typing import Union
+
 import numpy as np
 from pyproj import CRS
 import pyvista as pv
@@ -14,6 +16,7 @@ import pyvista as pv
 from .common import GV_FIELD_CRS
 
 __all__ = [
+    "CRSLike",
     "PlateCarree",
     "WGS84",
     "from_wkt",
@@ -22,6 +25,9 @@ __all__ = [
     "set_central_meridian",
     "to_wkt",
 ]
+
+# type aliases
+CRSLike = Union[int, str, dict, CRS]
 
 #: EPSG projection parameter for longitude of natural origin/central meridian
 EPSG_CENTRAL_MERIDIAN: str = "8802"

--- a/src/geovista/examples/from_2d__orca_moll.py
+++ b/src/geovista/examples/from_2d__orca_moll.py
@@ -47,7 +47,7 @@ def main() -> None:
     mesh = cast(mesh.threshold())
 
     # transform and extrude the mesh
-    mesh = transform_mesh(mesh, crs)
+    mesh = transform_mesh(crs, mesh)
     mesh.extrude((0, 0, -1000000), capping=True, inplace=True)
 
     # plot the mesh

--- a/src/geovista/examples/from_2d__orca_moll.py
+++ b/src/geovista/examples/from_2d__orca_moll.py
@@ -47,7 +47,7 @@ def main() -> None:
     mesh = cast(mesh.threshold())
 
     # transform and extrude the mesh
-    mesh = transform_mesh(crs, mesh)
+    mesh = transform_mesh(mesh, crs)
     mesh.extrude((0, 0, -1000000), capping=True, inplace=True)
 
     # plot the mesh

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -213,7 +213,7 @@ class GeoPlotterBase:
         to_wkt(mesh, WGS84)
         # the point-cloud won't be sliced, however it's important that the
         # central-meridian rotation is performed here
-        mesh = transform_mesh(self.crs, mesh, zlevel=zlevel, inplace=True)
+        mesh = transform_mesh(mesh, self.crs, zlevel=zlevel, inplace=True)
         xyz = mesh.points
 
         if "show_points" in point_labels_args:
@@ -598,8 +598,8 @@ class GeoPlotterBase:
 
             if transform_required:
                 mesh = transform_mesh(
-                    tgt_crs,
                     mesh,
+                    tgt_crs,
                     slice_connectivity=False,
                     rtol=rtol,
                     atol=atol,

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -10,7 +10,7 @@ Notes
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any, Union
+from typing import Any
 from warnings import warn
 
 from pyproj import CRS
@@ -51,9 +51,6 @@ from .samples import LFRIC_RESOLUTION, REGULAR_RESOLUTION, lfric, regular_grid
 from .transform import transform_mesh
 
 __all__ = ["GeoPlotter"]
-
-# type aliases
-CRSLike = Union[int, str, dict, CRS]
 
 #: Proportional multiplier for z-axis levels/offsets of base-layer mesh.
 BASE_ZLEVEL_SCALE: int = 1.0e-3
@@ -216,7 +213,7 @@ class GeoPlotterBase:
         to_wkt(mesh, WGS84)
         # the point-cloud won't be sliced, however it's important that the
         # central-meridian rotation is performed here
-        mesh = transform_mesh(mesh, self.crs, zlevel=zlevel, inplace=True)
+        mesh = transform_mesh(self.crs, mesh, zlevel=zlevel, inplace=True)
         xyz = mesh.points
 
         if "show_points" in point_labels_args:
@@ -601,8 +598,8 @@ class GeoPlotterBase:
 
             if transform_required:
                 mesh = transform_mesh(
-                    mesh,
                     tgt_crs,
+                    mesh,
                     slice_connectivity=False,
                     rtol=rtol,
                     atol=atol,

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -318,7 +318,7 @@ def transform_points(
             raise ValueError(emsg)
 
     def combine(xs: ArrayLike, ys: ArrayLike, zs: ArrayLike | None = None) -> ArrayLike:
-        """Combine the provided points into a single array with shape (N,3).
+        """Combine the provided points into a single array with shape (N, 3).
 
         Parameters
         ----------
@@ -362,6 +362,6 @@ def transform_points(
 
     if xndim == 2:
         shape.append(3)
-        result = result.reshape(**shape)
+        result = result.reshape(tuple(shape))
 
     return result

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -214,7 +214,9 @@ def transform_point(
     .. versionadded:: 0.4.0
 
     """
-    result = transform_points(src_crs, tgt_crs, x, y, z, trap=trap)
+    result = transform_points(
+        src_crs=src_crs, tgt_crs=tgt_crs, xs=x, ys=y, zs=z, trap=trap
+    )
     shape = result.shape
     assert shape == (1, 3), f"Cannot transform point, got unexpected shape {shape}."
     return result[0]

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -32,8 +32,8 @@ __all__ = [
 
 
 def transform_mesh(
-    tgt_crs: CRSLike,
     mesh: pv.PolyData,
+    tgt_crs: CRSLike,
     slice_connectivity: bool | None = True,
     rtol: float | None = None,
     atol: float | None = None,
@@ -45,11 +45,11 @@ def transform_mesh(
 
     Parameters
     ----------
-    tgt_crs : CRSLike
-        The target coordinate reference system (CRS) of the transformation.
     mesh : PolyData
         The mesh to be transformed from its source coordinate reference system (CRS) to
         the given `tgt_crs`.
+    tgt_crs : CRSLike
+        The target coordinate reference system (CRS) of the transformation.
     slice_connectivity : bool, default=True
         Slice the mesh prior to transformation in order to break mesh connectivity and
         create a seam in the mesh. Also see :func:`geovista.core.slice_mesh`.

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -179,22 +179,22 @@ def transform_point(
     Parameters
     ----------
     src_crs : CRSLike
-        The source Coordinate Reference System (CRS) of the provided `xs`,
-        `ys` and `zs` spatial point. May be anything accepted by
+        The source Coordinate Reference System (CRS) of the provided `x`,
+        `y` and `z` spatial point. May be anything accepted by
         :meth:`pyproj.CRS.from_user_input`.
     tgt_crs : CRSLike
         The target Coordinate Reference System (CRS) of the transform for
         the spatial point. May be anything accepted by
         :meth:`pyproj.CRS.from_user_input`.
-    xs : ArrayLike
+    x : ArrayLike
         The spatial point x-value, in canonical `src_crs` units, to be
         transformed from the `src_crs` to the `tgt_crs`. May be scalar
         or 1-D.
-    ys : ArrayLike
+    y : ArrayLike
         The spatial point y-value, in canonical `src_crs` units, to be
         transformed from the `src_crs` to the `tgt_crs`. May be scalar
         or 1-D.
-    zs : ArrayLike, optional
+    z : ArrayLike, optional
         The spatial point z-value, in canonical `src_crs` units, to be
         transformed from the `src_crs` to the `tgt_crs`. May be scalar
         or 1-D.

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -9,22 +9,31 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import numpy as np
 from numpy.typing import ArrayLike
 from pyproj import CRS, Transformer
 import pyvista as pv
 
 from .common import GV_FIELD_ZSCALE, ZLEVEL_SCALE, from_cartesian, point_cloud
-from .core import slice_mesh
-from .crs import WGS84, from_wkt, get_central_meridian, set_central_meridian, to_wkt
+from .crs import (
+    WGS84,
+    CRSLike,
+    from_wkt,
+    get_central_meridian,
+    set_central_meridian,
+    to_wkt,
+)
 
 __all__ = [
     "transform_mesh",
+    "transform_point",
+    "transform_points",
 ]
 
 
 def transform_mesh(
+    tgt_crs: CRSLike,
     mesh: pv.PolyData,
-    tgt_crs: CRS,
     slice_connectivity: bool | None = True,
     rtol: float | None = None,
     atol: float | None = None,
@@ -36,11 +45,11 @@ def transform_mesh(
 
     Parameters
     ----------
+    tgt_crs : CRSLike
+        The target coordinate reference system (CRS) of the transformation.
     mesh : PolyData
         The mesh to be transformed from its source coordinate reference system (CRS) to
         the given `tgt_crs`.
-    tgt_crs : CRS
-        The target coordinate reference system (CRS) of the transformation.
     slice_connectivity : bool, default=True
         Slice the mesh prior to transformation in order to break mesh connectivity and
         create a seam in the mesh. Also see :func:`geovista.core.slice_mesh`.
@@ -72,11 +81,16 @@ def transform_mesh(
     .. versionadded:: 0.3.0
 
     """
+    from .core import slice_mesh
+
     src_crs = from_wkt(mesh)
 
     if src_crs is None:
         emsg = "Cannot transform mesh, no coordinate reference system (CRS) attached."
         raise ValueError(emsg)
+
+    # sanity check the target crs
+    tgt_crs = CRS.from_user_input(tgt_crs)
 
     original_tgt_crs = deepcopy(tgt_crs)
     transform_required = src_crs != tgt_crs
@@ -118,8 +132,10 @@ def transform_mesh(
         else:
             xyz = mesh.points
 
-        transformer = Transformer.from_crs(src_crs, tgt_crs, always_xy=True)
-        xs, ys = transformer.transform(xyz[:, 0], xyz[:, 1], errcheck=True)
+        transformed = transform_points(
+            src_crs=src_crs, tgt_crs=tgt_crs, xs=xyz[:, 0], ys=xyz[:, 1]
+        )
+        xs, ys = transformed[:, 0], transformed[:, 1]
         zs = 0
 
         if not inplace and not slice_connectivity:
@@ -137,6 +153,7 @@ def transform_mesh(
             delta = max(xdelta, ydelta) // 4
 
             if cloud:
+                # extract the zlevel encoded from the non-transformed points
                 zlevel += xyz[:, 2]
 
             zs = zlevel * zscale * delta
@@ -147,3 +164,202 @@ def transform_mesh(
         to_wkt(mesh, original_tgt_crs)
 
     return mesh
+
+
+def transform_point(
+    src_crs: CRSLike,
+    tgt_crs: CRSLike,
+    x: int | float,
+    y: int | float,
+    z: int | float | None = None,
+    trap: bool | None = True,
+) -> ArrayLike:
+    """Transform the spatial point from the source to the target CRS.
+
+    Parameters
+    ----------
+    src_crs : CRSLike
+        The source Coordinate Reference System (CRS) of the provided `xs`,
+        `ys` and `zs` spatial point. May be anything accepted by
+        :meth:`pyproj.CRS.from_user_input`.
+    tgt_crs : CRSLike
+        The target Coordinate Reference System (CRS) of the transform for
+        the spatial point. May be anything accepted by
+        :meth:`pyproj.CRS.from_user_input`.
+    xs : ArrayLike
+        The spatial point x-value, in canonical `src_crs` units, to be
+        transformed from the `src_crs` to the `tgt_crs`. May be scalar
+        or 1-D.
+    ys : ArrayLike
+        The spatial point y-value, in canonical `src_crs` units, to be
+        transformed from the `src_crs` to the `tgt_crs`. May be scalar
+        or 1-D.
+    zs : ArrayLike, optional
+        The spatial point z-value, in canonical `src_crs` units, to be
+        transformed from the `src_crs` to the `tgt_crs`. May be scalar
+        or 1-D.
+    trap : bool, default=True
+        Raise an exception if an error occurs during CRS transformation
+        of the spatial point. Otherwise, ``inf`` will be returned for
+        the erroneous point.
+
+    Returns
+    -------
+    ArrayLike
+        The transformed spatial point in the canonical units of the target
+        CRS. The shape of the result will be ``(3,)``.
+
+    Notes
+    -----
+    .. versionadded:: 0.4.0
+
+    """
+    result = transform_points(src_crs, tgt_crs, x, y, z, trap=trap)
+    shape = result.shape
+    assert shape == (1, 3), f"Cannot transform point, got unexpected shape {shape}."
+    return result[0]
+
+
+def transform_points(
+    src_crs: CRSLike,
+    tgt_crs: CRSLike,
+    xs: ArrayLike,
+    ys: ArrayLike,
+    zs: ArrayLike | None = None,
+    trap: bool | None = True,
+) -> ArrayLike:
+    """Transform the spatial points from the source to the target CRS.
+
+    Parameters
+    ----------
+    src_crs : CRSLike
+        The source Coordinate Reference System (CRS) of the provided `xs`,
+        `ys` and `zs` spatial points. May be anything accepted by
+        :meth:`pyproj.CRS.from_user_input`.
+    tgt_crs : CRSLike
+        The target Coordinate Reference System (CRS) of the transform for
+        the spatial points. May be anything accepted by
+        :meth:`pyproj.CRS.from_user_input`.
+    xs : ArrayLike
+        The spatial points x-values, in canonical `src_crs` units, to be
+        transformed from the `src_crs` to the `tgt_crs`. May be scalar,
+        1-D or 2-D.
+    ys : ArrayLike
+        The spatial points y-values, in canonical `src_crs` units, to be
+        transformed from the `src_crs` to the `tgt_crs`. May be scalar,
+        1-D or 2-D.
+    zs : ArrayLike, optional
+        The spatial points z-values, in canonical `src_crs` units, to be
+        transformed from the `src_crs` to the `tgt_crs`. May be scalar,
+        1-D or 2-D.
+    trap : bool, default=True
+        Raise an exception if an error occurs during CRS transformation
+        of the spatial points. Otherwise, ``inf`` will be returned for
+        erroneous points.
+
+    Returns
+    -------
+    ArrayLike
+        The transformed spatial points in the canonical units of the target
+        CRS. The shape of the result will either be ``(1, 3)``, ``(M, 3)``
+        or ``(M, N, 3)`` depending on whether the provided spatial points
+        were scalar, 1-D or 2-D, respectively.
+
+    Notes
+    -----
+    .. versionadded:: 0.4.0
+
+    """
+    xs = np.atleast_1d(xs)
+    ys = np.atleast_1d(ys)
+
+    if zs is not None:
+        zs = np.atleast_1d(zs)
+
+    # sanity check the crs's
+    src_crs = CRS.from_user_input(src_crs)
+    tgt_crs = CRS.from_user_input(tgt_crs)
+
+    # sanity check spatial arrays
+    if (xndim := xs.ndim) > 2 or (yndim := ys.ndim) > 2:
+        emsg = "Cannot transform points, 'xs' and 'ys' must be 1-D or 2-D only."
+        raise ValueError(emsg)
+
+    shape = list(xs.shape)
+
+    if xndim != 1:
+        xs = xs.flatten()
+
+    if yndim != 1:
+        ys = ys.flatten()
+
+    if xs.size != ys.size:
+        emsg = (
+            "Cannot transform points, 'xs' and 'ys' require same length, "
+            f"got {xs.size:,} and {ys.size:,} respectively."
+        )
+        raise ValueError(emsg)
+
+    if zs is not None:
+        if (zndim := zs.ndim) > 2:
+            emsg = "Cannot transform points, 'zs' must be 1-D or 2-D only."
+            raise ValueError(emsg)
+
+        if zndim != 1:
+            zs = zs.flatten()
+
+        if zs.size != xs.size:
+            emsg = (
+                "Cannot transform points, 'xs' and 'zs' require same length "
+                f"got {xs.size:,} and {zs.size:,} respectively."
+            )
+            raise ValueError(emsg)
+
+    def combine(xs: ArrayLike, ys: ArrayLike, zs: ArrayLike | None = None) -> ArrayLike:
+        """Combine the provided points into a single array with shape (N,3).
+
+        Parameters
+        ----------
+        xs : ArrayLike
+            The x-coordinate points with shape (N,).
+        ys : ArrayLike
+            The y-coordinate points with shape (N,).
+        zs : ArrayLike, optional
+            The z-coordinate points with shape (N,).
+
+        Returns
+        -------
+        ArrayLike
+            The (N, 3) array combined from `xs`, `ys`, and `zs`.
+
+        Notes
+        -----
+        .. versionadded:: 0.4.0
+
+        """
+        if zs is None:
+            zs = np.zeros_like(xs)
+
+        assert (
+            xs.shape == ys.shape == zs.shape
+        ), "Cannot combine points, non-uniform shapes."
+        return np.vstack([xs, ys, zs]).T
+
+    if src_crs == tgt_crs:
+        result = combine(xs, ys, zs)
+    else:
+        transformer = Transformer.from_crs(src_crs, tgt_crs, always_xy=True)
+        transformed = transformer.transform(xs, ys, zs, errcheck=trap)
+
+        if zs is None:
+            (txs, tys), tzs = transformed, None
+        else:
+            txs, tys, tzs = transformed
+
+        result = combine(txs, tys, tzs)
+
+    if xndim == 2:
+        shape.append(3)
+        result = result.reshape(**shape)
+
+    return result

--- a/tests/transform/__init__.py
+++ b/tests/transform/__init__.py
@@ -1,0 +1,1 @@
+"""Unit-tests for :mod:`geovista.transform`."""

--- a/tests/transform/test_transform_point.py
+++ b/tests/transform/test_transform_point.py
@@ -21,7 +21,7 @@ def test_shape_fail(mocker, bad):
     patcher = mocker.patch("geovista.transform.transform_points", return_value=bad)
     emsg = "Cannot transform point, got unexpected shape"
     with pytest.raises(AssertionError, match=emsg):
-        transform_point(src_crs=src_crs, tgt_crs=tgt_crs, x=x, y=y, z=z, trap=trap)
+        _ = transform_point(src_crs=src_crs, tgt_crs=tgt_crs, x=x, y=y, z=z, trap=trap)
     patcher.assert_called_once_with(
         src_crs=src_crs,
         tgt_crs=tgt_crs,
@@ -33,13 +33,13 @@ def test_shape_fail(mocker, bad):
 
 
 @pytest.mark.parametrize(
-    "extract",
+    "extract_xyz",
     [lambda arg: arg, lambda arg: arg.reshape(3, 1)],
 )
-def test_valid_pass_thru(extract):
+def test_valid_pass_thru(extract_xyz):
     """Test transforming scalar spatial values."""
     expected = np.array([0, 1, 2], dtype=float)
-    x, y, z = extract(expected)
+    x, y, z = extract_xyz(expected)
     result = transform_point(src_crs=WGS84, tgt_crs=WGS84, x=x, y=y, z=z)
     assert result.shape == expected.shape
     np.testing.assert_array_equal(result, expected)

--- a/tests/transform/test_transform_points.py
+++ b/tests/transform/test_transform_points.py
@@ -91,7 +91,9 @@ def test_transform(mocker, zoffset, reshape, roundtrip):
     spy_from_crs = mocker.spy(Transformer, "from_crs")
     spy_transform = mocker.spy(Transformer, "transform")
     if roundtrip:
-        points = transform_points(src_crs=WGS84, tgt_crs="+proj=eqc", xs=xs, ys=ys, zs=zs)
+        points = transform_points(
+            src_crs=WGS84, tgt_crs="+proj=eqc", xs=xs, ys=ys, zs=zs
+        )
         result = transform_points(
             src_crs="+proj=eqc",
             tgt_crs=WGS84,

--- a/tests/transform/test_transform_points.py
+++ b/tests/transform/test_transform_points.py
@@ -2,10 +2,22 @@
 from __future__ import annotations
 
 import numpy as np
+from pyproj.exceptions import CRSError
 import pytest
 
 from geovista.crs import WGS84
 from geovista.transform import transform_points
+
+
+@pytest.mark.parametrize(
+    "src_crs, tgt_crs", [(None, WGS84), (WGS84, None), (None, None)]
+)
+def test_crs_fail(src_crs, tgt_crs):
+    """Test trap of invalid source and/or target CRSs."""
+    data = np.empty(1)
+    emsg = "Invalid projection"
+    with pytest.raises(CRSError, match=emsg):
+        _ = transform_points(src_crs=src_crs, tgt_crs=tgt_crs, xs=data, ys=data)
 
 
 @pytest.mark.parametrize(
@@ -29,3 +41,32 @@ def test_xy_dimension_fail(xbad, ybad):
         emsg = "Cannot transform points, 'xs' and 'ys' must be 1-D or 2-D only"
         with pytest.raises(ValueError, match=emsg):
             _ = transform_points(src_crs=WGS84, tgt_crs=WGS84, xs=xs, ys=ys)
+
+
+@pytest.mark.parametrize(
+    "xs, ys",
+    [(np.arange(10), np.arange(20)), (np.arange(10), np.arange(20).reshape(10, 2))],
+)
+def test_xy_size_fail(xs, ys):
+    """Test trap of unequal number of x-axis and y-axis samples."""
+    emsg = "Cannot transform points, 'xs' and 'ys' require same length"
+    with pytest.raises(ValueError, match=emsg):
+        _ = transform_points(src_crs=WGS84, tgt_crs=WGS84, xs=xs, ys=ys)
+
+
+def test_z_dimension_fail():
+    """Test trap of non-compliant zs dimensionality."""
+    data = np.empty(1)
+    zs = np.empty(1).reshape(1, 1, 1)
+    emsg = "Cannot transform points, 'zs' must be 1-D or 2-D"
+    with pytest.raises(ValueError, match=emsg):
+        _ = transform_points(src_crs=WGS84, tgt_crs=WGS84, xs=data, ys=data, zs=zs)
+
+
+def test_z_size_fail():
+    """Test trap of unequal number of z-axis samples."""
+    data = np.empty(1)
+    zs = np.empty(2)
+    emsg = "Cannot transform points, 'xs' and 'zs' require same length"
+    with pytest.raises(ValueError, match=emsg):
+        _ = transform_points(src_crs=WGS84, tgt_crs=WGS84, xs=data, ys=data, zs=zs)

--- a/tests/transform/test_transform_points.py
+++ b/tests/transform/test_transform_points.py
@@ -91,13 +91,13 @@ def test_transform(mocker, zoffset, reshape, roundtrip):
     spy_from_crs = mocker.spy(Transformer, "from_crs")
     spy_transform = mocker.spy(Transformer, "transform")
     if roundtrip:
-        tmp = transform_points(src_crs=WGS84, tgt_crs="+proj=eqc", xs=xs, ys=ys, zs=zs)
+        points = transform_points(src_crs=WGS84, tgt_crs="+proj=eqc", xs=xs, ys=ys, zs=zs)
         result = transform_points(
             src_crs="+proj=eqc",
             tgt_crs=WGS84,
-            xs=tmp[..., 0],
-            ys=tmp[..., 1],
-            zs=tmp[..., 2],
+            xs=points[..., 0],
+            ys=points[..., 1],
+            zs=points[..., 2],
         )
     else:
         result = transform_points(src_crs=WGS84, tgt_crs=WGS84, xs=xs, ys=ys, zs=zs)

--- a/tests/transform/test_transform_points.py
+++ b/tests/transform/test_transform_points.py
@@ -1,0 +1,31 @@
+"""Unit-tests for :func:`geovista.transform.transform_points`."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from geovista.crs import WGS84
+from geovista.transform import transform_points
+
+
+@pytest.mark.parametrize(
+    "xbad, ybad",
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test_xy_dimension_fail(xbad, ybad):
+    """Test trap of non-compliant xs and/or ys dimensionality."""
+    xs = np.arange(size := 24)
+    ys = np.arange(size)
+    if xbad:
+        xs = xs.reshape((2, 3, 4))
+    if ybad:
+        ys = ys.reshape((2, 3, 4))
+    bad = xbad or ybad
+    if bad:
+        emsg = "Cannot transform points, 'xs' and 'ys' must be 1-D or 2-D only"
+        with pytest.raises(ValueError, match=emsg):
+            _ = transform_points(src_crs=WGS84, tgt_crs=WGS84, xs=xs, ys=ys)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR extends the `geovista.transform` API to also support `transform_point` and `transform_points`, alongside the already existing `transform_mesh` function.

I've been building up to this PR for a long while, but it's the first step in opening up some of the core functionality to allow users the ability to manipulate meshes for more complex workflows, rather than just rendering them in a scene. 

Test coverage:

- [x] `geovista.transform.transform_point`
- [x] `geovista.transform.transform_points`

---
