### PR TITLE
generate opacity warning for gpu renderer and versions blacklist

### DIFF
--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -57,6 +57,7 @@ __all__ = [
     "triangulated",
     "vtk_warnings_off",
     "vtk_warnings_on",
+    "warn_opacity",
     "wrap",
 ]
 
@@ -102,6 +103,11 @@ JUPYTER_BACKEND: str = "trame"
 
 #: LRU cache size, which is auto-disabled for testing
 LRU_CACHE_SIZE: int = 0 if "pytest" in sys.modules else 128
+
+#: Known GPU renderer and version combinations that don't support opacity.
+OPACITY_BLACKLIST = [
+    ("llvmpipe (LLVM 7.0, 256 bits)", "3.3 (Core Profile) Mesa 18.3.4"),
+]
 
 #: Default period for wrapped longitude half-open interval, in degrees.
 PERIOD: float = 360.0
@@ -879,6 +885,35 @@ def vtk_warnings_on() -> None:
     vtkObject.GlobalWarningDisplayOn()
     # https://gitlab.kitware.com/vtk/vtk/-/issues/18785
     vtkLogger.SetStderrVerbosity(vtkLogger.VERBOSITY_INFO)
+
+
+def warn_opacity(plotter: pv.Plotter) -> None:
+    """Add text opacity support warning to plotter scene.
+
+    Convenience for adding a text warning to the render scene for known GPU
+    configurations that don't support opacity.
+
+    Parameters
+    ----------
+    plotter : pv.Plotter
+        The plotter rendering the scene.
+
+    Notes
+    -----
+    .. versionadded:: 0.4.0
+
+    """
+    info = pv.GPUInfo()
+    renderer_version = info.renderer, info.version
+
+    if renderer_version in OPACITY_BLACKLIST:
+        plotter.add_text(
+            "Requires Opacity Support",
+            position="lower_right",
+            font_size=7,
+            color="red",
+            shadow=True,
+        )
 
 
 def wrap(

--- a/src/geovista/examples/clouds.py
+++ b/src/geovista/examples/clouds.py
@@ -12,6 +12,7 @@ import cmocean
 from matplotlib.colors import LinearSegmentedColormap
 
 import geovista as gv
+from geovista.common import warn_opacity
 from geovista.pantry import cloud_amount
 import geovista.theme  # noqa: F401
 
@@ -91,6 +92,7 @@ def main() -> None:
         font_size=10,
         shadow=True,
     )
+    warn_opacity(plotter)
     plotter.camera.zoom(1.5)
     plotter.show()
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR allows the ability to generate a text opacity warning which is added to the plotter scene for known troublesome GPU renderer and version combinations.

e.g., the following is generated with the `clouds.py` example on the Met Office VDI estate, where there are no GPUs and a llvmpipe rasterizer is being used with an older version of OpenGL.

![image](https://github.com/bjlittle/geovista/assets/2051656/17d03f35-4d24-47e3-a104-36dd4d37233c)

---
