### PR TITLE
add opacity to point-cloud examples

### DIFF
--- a/src/geovista/examples/clouds.py
+++ b/src/geovista/examples/clouds.py
@@ -94,7 +94,7 @@ def main() -> None:
         shadow=True,
     )
     plotter.camera.zoom(1.5)
-    # generate warning, if no gpu opacity support
+    # generate warning, if no gpu opacity support available
     warn_opacity(plotter)
     plotter.show()
 

--- a/src/geovista/examples/clouds_robin.py
+++ b/src/geovista/examples/clouds_robin.py
@@ -95,7 +95,7 @@ def main() -> None:
     )
     plotter.view_xy()
     plotter.camera.zoom(1.5)
-    # generate warning, if no gpu opacity support
+    # generate warning, if no gpu opacity support available
     warn_opacity(plotter)
     plotter.show()
 

--- a/src/geovista/examples/earthquakes.py
+++ b/src/geovista/examples/earthquakes.py
@@ -70,6 +70,7 @@ def main() -> None:
         point_size=5,
         scalar_bar_args=sargs,
     )
+    # force zlevel alignment of coastlines and base layer
     plotter.add_base_layer(texture=gv.natural_earth_1(), zlevel=0)
     plotter.add_graticule()
     plotter.add_coastlines()

--- a/src/geovista/examples/from_points__orca_cloud.py
+++ b/src/geovista/examples/from_points__orca_cloud.py
@@ -8,6 +8,7 @@ Notes
 from __future__ import annotations
 
 import geovista as gv
+from geovista.common import warn_opacity
 from geovista.pantry import um_orca2_gradient
 from geovista.samples import ZLEVEL_SCALE_CLOUD
 import geovista.theme  # noqa: F401
@@ -18,11 +19,12 @@ def main() -> None:
 
     The resulting mesh contains only points.
 
-    Based on a curvilinear ORCA2 global ocean with tri-polar model grid of sea water
-    potential temperature data, which has been reduced to a limited area and
-    pre-filtered for temperature gradients.
+    Based on a curvilinear ORCA2 global ocean with tri-polar model grid of
+    sea water potential temperature data, which has been reduced to a limited
+    area and pre-filtered for temperature gradients.
 
-    Note that, Natural Earth coastlines are also rendered.
+    Note that, Natural Earth coastlines are also rendered along with a Natural
+    Earth base layer with opacity.
 
     """
     # load the sample data
@@ -52,6 +54,8 @@ def main() -> None:
         render_points_as_spheres=True,
     )
     plotter.add_coastlines(color="black")
+    # force zlevel alignment of coastlines and base layer
+    plotter.add_base_layer(texture=gv.natural_earth_1(), opacity=0.5, zlevel=0)
     plotter.add_axes()
     plotter.view_yz()
     plotter.add_text(
@@ -60,6 +64,8 @@ def main() -> None:
         font_size=10,
         shadow=True,
     )
+    # generate warning, if no gpu opacity support available
+    warn_opacity(plotter)
     plotter.show()
 
 

--- a/src/geovista/examples/from_points__orca_cloud_eqc.py
+++ b/src/geovista/examples/from_points__orca_cloud_eqc.py
@@ -8,6 +8,7 @@ Notes
 from __future__ import annotations
 
 import geovista as gv
+from geovista.common import warn_opacity
 from geovista.pantry import um_orca2_gradient
 from geovista.samples import ZLEVEL_SCALE_CLOUD
 import geovista.theme  # noqa: F401
@@ -18,12 +19,14 @@ def main() -> None:
 
     The resulting mesh contains only points.
 
-    Based on a curvilinear ORCA2 global ocean with tri-polar model grid of sea water
-    potential temperature data, which has been reduced to a limited area and
-    pre-filtered for temperature gradients.
+    Based on a curvilinear ORCA2 global ocean with tri-polar model grid of
+    sea water potential temperature data, which has been reduced to a limited
+    area and pre-filtered for temperature gradients.
 
-    Note that, Natural Earth coastlines are also rendered, and the mesh is transformed
-    to the Equidistant Cylindrical (Plate Carrée) conformal cylindrical projection.
+    Note that, Natural Earth coastlines are also rendered along with a Natural
+    Earth base layer with opacity. Additionally, the mesh is transformed to
+    the Equidistant Cylindrical (Plate Carrée) conformal cylindrical
+    projection.
 
     """
     # load the sample data
@@ -53,14 +56,19 @@ def main() -> None:
         render_points_as_spheres=True,
     )
     plotter.add_coastlines(color="black")
+    # force zlevel alignment of coastlines and base layer
+    plotter.add_base_layer(texture=gv.natural_earth_1(), opacity=0.5, zlevel=0)
     plotter.add_axes()
     plotter.view_xy()
+    plotter.camera.zoom(1.5)
     plotter.add_text(
         "ORCA Point-Cloud (10m Coastlines)",
         position="upper_left",
         font_size=10,
         shadow=True,
     )
+    # generate warning, if no gpu opacity support available
+    warn_opacity(plotter)
     plotter.show()
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

When opacity is supported, the `from_points__orca_cloud` example now renders as:

![point-cloud](https://github.com/bjlittle/geovista/assets/2051656/578423fb-31fa-41ce-886f-3a7b04eb78f2)

And the `from_points__orca_cloud_eqc` example now renders as:

![point-cloud-eqc](https://github.com/bjlittle/geovista/assets/2051656/8a9bd646-7f4b-4659-8b90-cee05a7af1bf)

---
