### PR TITLE
fix geovista.core.slice_lines for pyvista 0.42

### DIFF
--- a/tests/core/test_slice_lines.py
+++ b/tests/core/test_slice_lines.py
@@ -62,10 +62,22 @@ def test_no_traversal_slice(copy, mesh):
     assert result == mesh
 
 
+@pytest.mark.parametrize("copy", [False, True])
+@pytest.mark.parametrize("mesh", [line(180, [90, 0, -90]), line(-180, [-90, 0, 90])])
+def test_full_traversal_slice(copy, mesh):
+    """Test a line mesh that completely traverses the antimeridian."""
+    result = slice_lines(mesh, copy=copy)
+    if copy:
+        assert id(result) != id(mesh)
+    else:
+        assert id(result) == id(mesh)
+    assert result == mesh
+
+
 def antimeridian_count(mesh: pv.PolyData) -> int:
     """Count the number of points on the antimeridian of the mesh."""
     lonlat = from_cartesian(mesh)
-    mask = np.isclose(lonlat[:, 0], -180)
+    mask = np.isclose(np.abs(lonlat[:, 0]), 180)
     return np.sum(mask)
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
There is a slight change in behaviour between `pyvista` 0.41.1 and 0.42.0 for `slice_along_line`.

Previously it used to return an empty mesh when a target line is fully aligned with the slicing plane created from the slicing spline. From 0.42.0, points of intersection (but not all) are detected and returned, which causes issues e.g., for `-180` and `+180` meridian lines when projecting and `lon_0=0`.

This issue was highlighted by the example `from_unstructured__lfric_sst_bonne` failing.

---
