### PR TITLE
remove build number from gha ci caches

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -52,7 +52,6 @@ jobs:
     - name: "conda package cache"
       uses: ./.github/workflows/composite/conda-pkg-cache
       with:
-        cache_build: 0
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
 
@@ -69,7 +68,6 @@ jobs:
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache
       with:
-        cache_build: 1
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
         install_packages: "pip 'tox<4'"
@@ -81,8 +79,6 @@ jobs:
 
     - name: "tox cache"
       uses: ./.github/workflows/composite/tox-cache
-      with:
-        cache_build: 0
 
     - name: "lock (${{ matrix.version }})"
       env:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -64,7 +64,6 @@ jobs:
     - name: "conda package cache"
       uses: ./.github/workflows/composite/conda-pkg-cache
       with:
-        cache_build: 0
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
 
@@ -81,7 +80,6 @@ jobs:
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache
       with:
-        cache_build: 1
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
         install_packages: "cartopy pip 'tox<4'"
@@ -94,14 +92,12 @@ jobs:
     - name: "cartopy cache"
       uses: ./.github/workflows/composite/cartopy-cache
       with:
-        cache_build: 0
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
 
     - name: "tox cache"
       uses: ./.github/workflows/composite/tox-cache
       with:
-        cache_build: 0
         lock_file: ${{ env.LOCK_FILE }}
 
     - name: "${{ matrix.session }} (${{ matrix.version }})"

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -98,7 +98,6 @@ jobs:
     - name: "conda package cache"
       uses: ./.github/workflows/composite/conda-pkg-cache
       with:
-        cache_build: 0
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
 
@@ -115,7 +114,6 @@ jobs:
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache
       with:
-        cache_build: 1
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
         install_packages: "pip 'tox<4'"
@@ -128,7 +126,6 @@ jobs:
     - name: "tox cache"
       uses: ./.github/workflows/composite/tox-cache
       with:
-        cache_build: 0
         lock_file: ${{ env.LOCK_FILE }}
 
     - name: "test wheel (${{ matrix.version }})"

--- a/.github/workflows/composite/cartopy-cache/action.yml
+++ b/.github/workflows/composite/cartopy-cache/action.yml
@@ -6,10 +6,6 @@ description: "create and cache cartopy assets"
 #   - CONDA
 #
 inputs:
-  cache_build:
-    description: "conda environment cache build number"
-    required: false
-    default: "0"
   cache_period:
     description: "conda environment cache timestamp"
     required: true
@@ -24,7 +20,7 @@ runs:
       id: cartopy-cache
       with:
         path: ~/.local/share/cartopy
-        key: ${{ runner.os }}-cartopy-${{ inputs.env_name }}-p${{ inputs.cache_period }}-b${{ inputs.cache_build }}
+        key: ${{ runner.os }}-cartopy-${{ inputs.env_name }}-${{ inputs.cache_period }}
 
     - if: steps.cartopy-cache.outputs.cache-hit != 'true'
       env:

--- a/.github/workflows/composite/conda-env-cache/action.yml
+++ b/.github/workflows/composite/conda-env-cache/action.yml
@@ -6,10 +6,6 @@ description: "create and cache the conda environment"
 #   - CONDA
 #
 inputs:
-  cache_build:
-    description: "conda environment cache build number"
-    required: false
-    default: "0"
   cache_period:
     description: "conda environment cache timestamp"
     required: true
@@ -27,7 +23,7 @@ runs:
       id: conda-env-cache
       with:
         path: ${{ env.CONDA }}/envs/${{ inputs.env_name }}
-        key: ${{ runner.os }}-conda-env-${{ inputs.env_name }}-p${{ inputs.cache_period }}-b${{ inputs.cache_build }}
+        key: ${{ runner.os }}-conda-env-${{ inputs.env_name }}-${{ inputs.cache_period }}
 
     - if: steps.conda-env-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/composite/conda-pkg-cache/action.yml
+++ b/.github/workflows/composite/conda-pkg-cache/action.yml
@@ -2,10 +2,6 @@ name: "conda-pkg-cache"
 description: "cache the conda environment packages"
 
 inputs:
-  cache_build:
-    description: "conda environment cache build number"
-    required: false
-    default: "0"
   cache_period:
     description: "conda environment cache timestamp"
     required: true
@@ -19,4 +15,4 @@ runs:
     - uses: actions/cache@v3
       with:
         path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-pkgs-${{ inputs.env_name }}-p${{ inputs.cache_period }}-b${{ inputs.cache_build }}
+        key: ${{ runner.os }}-conda-pkg-${{ inputs.env_name }}-${{ inputs.cache_period }}

--- a/.github/workflows/composite/tox-cache/action.yml
+++ b/.github/workflows/composite/tox-cache/action.yml
@@ -2,10 +2,6 @@ name: "tox cache"
 description: "cache the tox test environment"
 
 inputs:
-  cache_build:
-    description: "tox cache build number"
-    required: false
-    default: "0"
   lock_file:
     description: "conda-lock environment requirements filename"
     required: false
@@ -17,4 +13,4 @@ runs:
     - uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/.tox
-        key: ${{ runner.os }}-tox-${{ matrix.session }}-${{ matrix.version }}-b${{ inputs.cache_build }}-${{ hashFiles(inputs.lock_file) }}
+        key: ${{ runner.os }}-tox-${{ matrix.session }}-${{ matrix.version }}-${{ hashFiles(inputs.lock_file) }}


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
The GHA GUI interface now provides an easy and convenient way to purge GHA CI caches, so there is no need to explicitly include a build number in the name of CI runner caches.

Rather than bump the build number in a PR, the cache can simple by purged from the GHA GUI instead.

---
