### PR TITLE
use default antialiasing

### DIFF
--- a/src/geovista/examples/vectors.py
+++ b/src/geovista/examples/vectors.py
@@ -31,10 +31,8 @@ def main() -> None:
 
     # plot mesh
     plotter = gv.GeoPlotter()
-    plotter.enable_anti_aliasing("ssaa")
-    plotter.add_base_layer(lighting=False)
-    plotter.add_coastlines(color="black", lighting=False)
-    plotter.add_mesh(sphere.arrows, lighting=False)
+    plotter.add_base_layer(texture=gv.natural_earth_1(), zlevel=0, lighting=False)
+    plotter.add_mesh(sphere.arrows, lighting=None)
     plotter.camera.zoom(1.5)
     plotter.add_axes()
     plotter.show()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Revert to using the default `pyvista` anti-aliasing `msaa` (https://github.com/pyvista/pyvista/pull/4793) for the `vectors` example.

Also, tweak the example to render a textured base layer, but with no coastlines.

![image](https://github.com/bjlittle/geovista/assets/2051656/1c18f10a-501c-4195-b3cd-394e768e8d30)


---
