### PR TITLE
reduce codecov coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,8 @@ coverage:
   status:
     project:
       default:
-        target: 20
-        threshold: 10%  # coverage can drop by up to <threshold>% while still posting success
+        target: auto
+        threshold: 5%  # coverage can drop by up to <threshold>% while still posting success
     patch: off
 
 ignore:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Encourage healthy pull-request test coverage by reducing the coverage drop threshold.

Also, adopt the `auto` option for `target` i.e., the minimum coverage ratio that the commit must meet to be considered a success. `auto` will use the coverage from the base commit (pull request base or parent commit) coverage to compare against.

---
