### PR TITLE
Enable off-screen rendering of examples

### DIFF
--- a/src/geovista/examples/clouds.py
+++ b/src/geovista/examples/clouds.py
@@ -30,7 +30,7 @@ cmaps: dict[str, LinearSegmentedColormap] = {
 }
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create meshes from 1-D latitude and longitude unstructured cell points.
 
     The resulting meshes contain quad cells and are constructed from CF UGRID
@@ -54,7 +54,7 @@ def main() -> None:
     clim = (cmin := 0.3, 1.0)
 
     # create the plotter
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
 
     for i, cloud in enumerate(cmaps):
         # load the sample data

--- a/src/geovista/examples/clouds_robin.py
+++ b/src/geovista/examples/clouds_robin.py
@@ -30,7 +30,7 @@ cmaps: dict[str, LinearSegmentedColormap] = {
 }
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create meshes from 1-D latitude and longitude unstructured cell points.
 
     The resulting meshes contain quad cells and are constructed from CF UGRID
@@ -54,7 +54,7 @@ def main() -> None:
     clim = (cmin := 0.3, 1.0)
 
     # create the plotter
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"), off_screen=off_screen)
 
     for i, cloud in enumerate(cmaps):
         # load the sample data

--- a/src/geovista/examples/clouds_robin.py
+++ b/src/geovista/examples/clouds_robin.py
@@ -54,7 +54,8 @@ def main(off_screen: bool = False) -> None:
     clim = (cmin := 0.3, 1.0)
 
     # create the plotter
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"), off_screen=off_screen)
+    crs = "+proj=robin"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
 
     for i, cloud in enumerate(cmaps):
         # load the sample data
@@ -87,7 +88,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"Low, Medium, High & Very High Cloud Amount ({projection})",
+        f"Low, Medium, High & Very High Cloud Amount ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/earthquakes.py
+++ b/src/geovista/examples/earthquakes.py
@@ -15,7 +15,7 @@ from geovista.pantry import usgs_earthquakes
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a point cloud from a USGS earthquakes dataset.
 
     The resulting render contains a point cloud of M2.5+ earthquakes along
@@ -56,7 +56,7 @@ def main() -> None:
         return
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": "Magnitude", "shadow": True}
     plotter.add_points(
         xs=sample.lons,

--- a/src/geovista/examples/earthquakes_wink1.py
+++ b/src/geovista/examples/earthquakes_wink1.py
@@ -15,7 +15,7 @@ from geovista.pantry import usgs_earthquakes
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a point cloud from a USGS earthquakes dataset.
 
     The resulting render contains a point cloud of M2.5+ earthquakes along
@@ -57,7 +57,9 @@ def main() -> None:
         return
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=wink1 +lon_0=180"))
+    plotter = gv.GeoPlotter(
+        crs=(projection := "+proj=wink1 +lon_0=180"), off_screen=off_screen
+    )
     sargs = {"title": "Magnitude", "shadow": True}
     plotter.add_points(
         xs=sample.lons,

--- a/src/geovista/examples/earthquakes_wink1.py
+++ b/src/geovista/examples/earthquakes_wink1.py
@@ -57,9 +57,8 @@ def main(off_screen: bool = False) -> None:
         return
 
     # plot the mesh
-    plotter = gv.GeoPlotter(
-        crs=(projection := "+proj=wink1 +lon_0=180"), off_screen=off_screen
-    )
+    crs = "+proj=wink1 +lon_0=180"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": "Magnitude", "shadow": True}
     plotter.add_points(
         xs=sample.lons,
@@ -76,7 +75,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"USGS M2.5+ Earthquakes, 2000-2018 ({projection})",
+        f"USGS M2.5+ Earthquakes, 2000-2018 ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_1d__oisst.py
+++ b/src/geovista/examples/from_1d__oisst.py
@@ -13,7 +13,7 @@ from geovista.pantry import oisst_avhrr_sst
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -39,7 +39,7 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.blue_marble())

--- a/src/geovista/examples/from_1d__oisst_eqc.py
+++ b/src/geovista/examples/from_1d__oisst_eqc.py
@@ -13,7 +13,7 @@ from geovista.pantry import oisst_avhrr_sst
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -41,7 +41,7 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.blue_marble())

--- a/src/geovista/examples/from_1d__oisst_eqc.py
+++ b/src/geovista/examples/from_1d__oisst_eqc.py
@@ -41,14 +41,15 @@ def main(off_screen: bool = False) -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"), off_screen=off_screen)
+    crs = "+proj=eqc"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.blue_marble())
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"NOAA/NCEI OISST AVHRR ({projection})",
+        f"NOAA/NCEI OISST AVHRR ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_1d__synthetic_face_m1_n1.py
+++ b/src/geovista/examples/from_1d__synthetic_face_m1_n1.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -38,7 +38,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="ice", scalar_bar_args=sargs, show_edges=True

--- a/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
+++ b/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
@@ -39,7 +39,8 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"), off_screen=off_screen)
+    crs = "+proj=robin"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="ice", scalar_bar_args=sargs, show_edges=True
@@ -47,7 +48,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"1-D Synthetic Face Data ({projection})",
+        f"1-D Synthetic Face Data ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
+++ b/src/geovista/examples/from_1d__synthetic_face_m1_n1_robin.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -39,7 +39,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"), off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="ice", scalar_bar_args=sargs, show_edges=True

--- a/src/geovista/examples/from_1d__synthetic_node_m1_n1.py
+++ b/src/geovista/examples/from_1d__synthetic_node_m1_n1.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -38,7 +38,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="ice", scalar_bar_args=sargs, show_edges=True

--- a/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
+++ b/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -39,7 +39,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"), off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh,

--- a/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
+++ b/src/geovista/examples/from_1d__synthetic_node_m1_n1_moll.py
@@ -39,7 +39,8 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"), off_screen=off_screen)
+    crs = "+proj=moll"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh,
@@ -51,7 +52,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"1-D Synthetic Node Data ({projection})",
+        f"1-D Synthetic Node Data ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_2d__orca.py
+++ b/src/geovista/examples/from_2d__orca.py
@@ -13,7 +13,7 @@ from geovista.pantry import um_orca2
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude curvilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -38,7 +38,7 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_1())

--- a/src/geovista/examples/from_2d__orca_moll.py
+++ b/src/geovista/examples/from_2d__orca_moll.py
@@ -17,7 +17,7 @@ import geovista.theme  # noqa: F401
 from geovista.transform import transform_mesh
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude curvilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -51,7 +51,7 @@ def main() -> None:
     mesh.extrude((0, 0, -1000000), capping=True, inplace=True)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=crs)
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_coastlines(color="black")

--- a/src/geovista/examples/from_2d__synthetic_face_m1n1.py
+++ b/src/geovista/examples/from_2d__synthetic_face_m1n1.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -39,7 +39,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the data
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="tempo", scalar_bar_args=sargs, show_edges=True

--- a/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
+++ b/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
@@ -40,7 +40,8 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the data
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"), off_screen=off_screen)
+    crs = "+proj=robin"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="tempo", scalar_bar_args=sargs, show_edges=True
@@ -48,7 +49,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"2-D Synthetic Face Data ({projection})",
+        f"2-D Synthetic Face Data ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
+++ b/src/geovista/examples/from_2d__synthetic_face_m1n1_robin.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -40,7 +40,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the data
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=robin"), off_screen=off_screen)
     sargs = sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh, clim=(0, 1), cmap="tempo", scalar_bar_args=sargs, show_edges=True

--- a/src/geovista/examples/from_2d__synthetic_node_m1n1.py
+++ b/src/geovista/examples/from_2d__synthetic_node_m1n1.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -39,7 +39,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     plotter.add_mesh(mesh, clim=(0, 1), cmap="tempo", show_edges=True)
     plotter.add_coastlines()
     plotter.add_axes()

--- a/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
+++ b/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
@@ -14,7 +14,7 @@ import geovista as gv
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude rectilinear cell bounds.
 
     The resulting mesh contains quad cells.
@@ -40,7 +40,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"), off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh,

--- a/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
+++ b/src/geovista/examples/from_2d__synthetic_node_m1n1_moll.py
@@ -40,7 +40,8 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"), off_screen=off_screen)
+    crs = "+proj=moll"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{name} / 1", "shadow": True}
     plotter.add_mesh(
         mesh,
@@ -52,7 +53,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"2-D Synthetic Node Data ({projection})",
+        f"2-D Synthetic Node Data ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_points__orca_cloud.py
+++ b/src/geovista/examples/from_points__orca_cloud.py
@@ -13,7 +13,7 @@ from geovista.samples import ZLEVEL_SCALE_CLOUD
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a point-cloud from 1-D latitude, longitude and z-levels.
 
     The resulting mesh contains only points.
@@ -43,7 +43,7 @@ def main() -> None:
     gv.logger.info("%s", cloud)
 
     # plot the point-cloud
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(
         cloud,

--- a/src/geovista/examples/from_points__orca_cloud_eqc.py
+++ b/src/geovista/examples/from_points__orca_cloud_eqc.py
@@ -45,7 +45,8 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", cloud)
 
     # plot the point-cloud
-    plotter = gv.GeoPlotter(crs="+proj=eqc", off_screen=off_screen)
+    crs = "+proj=eqc"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(
         cloud,
@@ -61,7 +62,7 @@ def main(off_screen: bool = False) -> None:
     plotter.view_xy()
     plotter.camera.zoom(1.5)
     plotter.add_text(
-        "ORCA Point-Cloud (10m Coastlines)",
+        f"ORCA Point-Cloud ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_points__orca_cloud_eqc.py
+++ b/src/geovista/examples/from_points__orca_cloud_eqc.py
@@ -13,7 +13,7 @@ from geovista.samples import ZLEVEL_SCALE_CLOUD
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a point-cloud from 1-D latitude, longitude and z-levels.
 
     The resulting mesh contains only points.
@@ -45,7 +45,7 @@ def main() -> None:
     gv.logger.info("%s", cloud)
 
     # plot the point-cloud
-    plotter = gv.GeoPlotter(crs="+proj=eqc")
+    plotter = gv.GeoPlotter(crs="+proj=eqc", off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(
         cloud,

--- a/src/geovista/examples/from_unstructured__fesom.py
+++ b/src/geovista/examples/from_unstructured__fesom.py
@@ -13,7 +13,7 @@ from geovista.pantry import fesom
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh is formed from masked connectivity, allowing the mesh to contain
@@ -39,7 +39,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())

--- a/src/geovista/examples/from_unstructured__fesom_fouc.py
+++ b/src/geovista/examples/from_unstructured__fesom_fouc.py
@@ -13,7 +13,7 @@ from geovista.pantry import fesom
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh is formed from masked connectivity, allowing the mesh to contain
@@ -44,7 +44,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=fouc"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=fouc"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     # require increased relative tolerance accuracy when cutting the mesh
     # at the anti-meridian due to its complex geometry

--- a/src/geovista/examples/from_unstructured__fesom_fouc.py
+++ b/src/geovista/examples/from_unstructured__fesom_fouc.py
@@ -44,7 +44,8 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=fouc"), off_screen=off_screen)
+    crs = "+proj=fouc"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     # require increased relative tolerance accuracy when cutting the mesh
     # at the anti-meridian due to its complex geometry
@@ -53,7 +54,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"AWI-CM FESOM v1.4 ({projection})",
+        f"AWI-CM FESOM v1.4 ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_unstructured__fvcom.py
+++ b/src/geovista/examples/from_unstructured__fvcom.py
@@ -13,7 +13,7 @@ from geovista.pantry import fvcom_tamar
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains triangular cells. The connectivity is required to
@@ -48,7 +48,7 @@ def main() -> None:
     mesh.warp_by_scalar(scalars="node", inplace=True, factor=2e-5)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(
         mesh, cmap="deep", scalars="face", show_edges=True, scalar_bar_args=sargs

--- a/src/geovista/examples/from_unstructured__icon.py
+++ b/src/geovista/examples/from_unstructured__icon.py
@@ -15,7 +15,7 @@ from geovista.pantry import icon_soil
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh contains triangular cells.
@@ -38,7 +38,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     cmap = mpl.colormaps.get_cmap("cet_CET_L17").resampled(lutsize=9)
     plotter.add_mesh(mesh, cmap=cmap, show_edges=True, scalar_bar_args=sargs)

--- a/src/geovista/examples/from_unstructured__icon_eqc.py
+++ b/src/geovista/examples/from_unstructured__icon_eqc.py
@@ -15,7 +15,7 @@ from geovista.pantry import icon_soil
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh contains triangular cells.
@@ -39,7 +39,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     cmap = mpl.colormaps.get_cmap("cet_CET_L17").resampled(lutsize=9)
     plotter.add_mesh(mesh, cmap=cmap, show_edges=True, scalar_bar_args=sargs)

--- a/src/geovista/examples/from_unstructured__icon_eqc.py
+++ b/src/geovista/examples/from_unstructured__icon_eqc.py
@@ -39,14 +39,15 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=eqc"), off_screen=off_screen)
+    crs = "+proj=eqc"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     cmap = mpl.colormaps.get_cmap("cet_CET_L17").resampled(lutsize=9)
     plotter.add_mesh(mesh, cmap=cmap, show_edges=True, scalar_bar_args=sargs)
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"ICON 160km Resolution Triangular Mesh ({projection})",
+        f"ICON 160km Resolution Triangular Mesh ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_unstructured__icosahedral.py
+++ b/src/geovista/examples/from_unstructured__icosahedral.py
@@ -13,7 +13,7 @@ from geovista.pantry import icosahedral
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh contains 6-sided (hexagonal) cells.
@@ -36,7 +36,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_coastlines()

--- a/src/geovista/examples/from_unstructured__icosahedral_poly.py
+++ b/src/geovista/examples/from_unstructured__icosahedral_poly.py
@@ -37,14 +37,15 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=poly"), off_screen=off_screen)
+    crs = "+proj=poly"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_coastlines()
     plotter.add_graticule()
     plotter.add_axes()
     plotter.add_text(
-        f"DYNAMICO Icosahedral ({projection})",
+        f"DYNAMICO Icosahedral ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_unstructured__icosahedral_poly.py
+++ b/src/geovista/examples/from_unstructured__icosahedral_poly.py
@@ -13,7 +13,7 @@ from geovista.pantry import icosahedral
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh contains 6-sided (hexagonal) cells.
@@ -37,7 +37,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=poly"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=poly"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_coastlines()

--- a/src/geovista/examples/from_unstructured__lam_pacific.py
+++ b/src/geovista/examples/from_unstructured__lam_pacific.py
@@ -13,7 +13,7 @@ from geovista.pantry import lam_pacific
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains quad cells and is constructed from CF UGRID unstructured
@@ -41,7 +41,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())

--- a/src/geovista/examples/from_unstructured__lam_pacific_moll.py
+++ b/src/geovista/examples/from_unstructured__lam_pacific_moll.py
@@ -42,14 +42,15 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"), off_screen=off_screen)
+    crs = "+proj=moll"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"CF UGRID LAM ({projection})",
+        f"CF UGRID LAM ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_unstructured__lam_pacific_moll.py
+++ b/src/geovista/examples/from_unstructured__lam_pacific_moll.py
@@ -13,7 +13,7 @@ from geovista.pantry import lam_pacific
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains quad cells and is constructed from CF UGRID unstructured
@@ -42,7 +42,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=moll"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())

--- a/src/geovista/examples/from_unstructured__lfric_orog.py
+++ b/src/geovista/examples/from_unstructured__lfric_orog.py
@@ -13,7 +13,7 @@ from geovista.pantry import lfric_orog
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains quad cells and is constructed from CF UGRID unstructured
@@ -41,7 +41,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_coastlines()

--- a/src/geovista/examples/from_unstructured__lfric_orog_warp.py
+++ b/src/geovista/examples/from_unstructured__lfric_orog_warp.py
@@ -13,7 +13,7 @@ from geovista.pantry import lfric_orog
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains quad cells and is constructed from CF UGRID unstructured
@@ -48,7 +48,7 @@ def main() -> None:
     mesh.warp_by_scalar(scalars=sample.name, inplace=True, factor=2e-5)
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs)
     plotter.add_axes()

--- a/src/geovista/examples/from_unstructured__lfric_sst.py
+++ b/src/geovista/examples/from_unstructured__lfric_sst.py
@@ -13,7 +13,7 @@ from geovista.pantry import lfric_sst
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains quad cells and is constructed from CF UGRID unstructured
@@ -44,7 +44,7 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_1())

--- a/src/geovista/examples/from_unstructured__lfric_sst_bonne.py
+++ b/src/geovista/examples/from_unstructured__lfric_sst_bonne.py
@@ -13,7 +13,7 @@ from geovista.pantry import lfric_sst
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains quad cells and is constructed from CF UGRID unstructured
@@ -45,7 +45,9 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=bonne +lat_1=10 +lon_0=180"))
+    plotter = gv.GeoPlotter(
+        crs=(projection := "+proj=bonne +lat_1=10 +lon_0=180"), off_screen=off_screen
+    )
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_1())

--- a/src/geovista/examples/from_unstructured__lfric_sst_bonne.py
+++ b/src/geovista/examples/from_unstructured__lfric_sst_bonne.py
@@ -45,9 +45,8 @@ def main(off_screen: bool = False) -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter(
-        crs=(projection := "+proj=bonne +lat_1=10 +lon_0=180"), off_screen=off_screen
-    )
+    crs = "+proj=bonne +lat_1=10 +lon_0=180"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_1())
@@ -55,7 +54,7 @@ def main(off_screen: bool = False) -> None:
     plotter.add_graticule()
     plotter.add_axes()
     plotter.add_text(
-        f"LFRic C48 Unstructured Cube-Sphere ({projection})",
+        f"LFRic C48 Unstructured Cube-Sphere ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_unstructured__smc.py
+++ b/src/geovista/examples/from_unstructured__smc.py
@@ -13,7 +13,7 @@ from geovista.pantry import ww3_global_smc
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh contains quad cells.
@@ -38,7 +38,7 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter()
+    plotter = gv.GeoPlotter(off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())

--- a/src/geovista/examples/from_unstructured__smc_sinu.py
+++ b/src/geovista/examples/from_unstructured__smc_sinu.py
@@ -13,7 +13,7 @@ from geovista.pantry import ww3_global_smc
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 2-D latitude and longitude unstructured cell bounds.
 
     The resulting mesh contains quad cells.
@@ -40,7 +40,7 @@ def main() -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=sinu"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=sinu"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())

--- a/src/geovista/examples/from_unstructured__smc_sinu.py
+++ b/src/geovista/examples/from_unstructured__smc_sinu.py
@@ -40,14 +40,15 @@ def main(off_screen: bool = False) -> None:
     mesh = mesh.threshold()
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=sinu"), off_screen=off_screen)
+    crs = "+proj=sinu"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, scalar_bar_args=sargs)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"WW3 Spherical Multi-Cell ({projection})",
+        f"WW3 Spherical Multi-Cell ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,

--- a/src/geovista/examples/from_unstructured__tri.py
+++ b/src/geovista/examples/from_unstructured__tri.py
@@ -13,7 +13,7 @@ from geovista.pantry import ww3_global_tri
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains triangular cells. The connectivity is required to

--- a/src/geovista/examples/from_unstructured__tri_hammer.py
+++ b/src/geovista/examples/from_unstructured__tri_hammer.py
@@ -13,7 +13,7 @@ from geovista.pantry import ww3_global_tri
 import geovista.theme  # noqa: F401
 
 
-def main() -> None:
+def main(off_screen: bool = False) -> None:
     """Create a mesh from 1-D latitude and longitude unstructured cell points.
 
     The resulting mesh contains triangular cells. The connectivity is required to
@@ -45,7 +45,7 @@ def main() -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=hammer"))
+    plotter = gv.GeoPlotter(crs=(projection := "+proj=hammer"), off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs, scalars=sample.name)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())

--- a/src/geovista/examples/from_unstructured__tri_hammer.py
+++ b/src/geovista/examples/from_unstructured__tri_hammer.py
@@ -45,14 +45,15 @@ def main(off_screen: bool = False) -> None:
     gv.logger.info("%s", mesh)
 
     # plot the mesh
-    plotter = gv.GeoPlotter(crs=(projection := "+proj=hammer"), off_screen=off_screen)
+    crs = "+proj=hammer"
+    plotter = gv.GeoPlotter(crs=crs, off_screen=off_screen)
     sargs = {"title": f"{sample.name} / {sample.units}", "shadow": True}
     plotter.add_mesh(mesh, show_edges=True, scalar_bar_args=sargs, scalars=sample.name)
     plotter.add_base_layer(texture=gv.natural_earth_hypsometric())
     plotter.add_coastlines()
     plotter.add_axes()
     plotter.add_text(
-        f"WW3 Triangular Mesh ({projection})",
+        f"WW3 Triangular Mesh ({crs})",
         position="upper_left",
         font_size=10,
         shadow=True,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR allows the `off_screen` kwarg to be passed to the `main` function of the `geovista.examples` scripts. This enables the ability to call the importable `main` function of the examples for GHA CI image testing with `off_screen=True`.

---
