### PR TITLE
Min pin cartopy>=0.22 for no GEOS

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -10,7 +10,7 @@ dependencies:
   - setuptools-scm >=7
 
 # core dependencies
-  - cartopy >=0.20
+  - cartopy >=0.22
   - click
   - click-default-group
   - numpy >=1.21

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -1,4 +1,4 @@
-cartopy>=0.20
+cartopy>=0.22
 click
 click-default-group
 cmocean


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR raises the minimum pin for `cartopy>=0.22` which drops the need for GEOS in preference for `shapely`.

Reference [cartopy #2083](https://github.com/SciTools/cartopy/pull/2083).

---
