### PR TITLE
Render with osmesa vtk in GHA CI

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: "lock (${{ matrix.version }})"
       env:
-        VTK_BUILD: "  - vtk=*=qt_*"
+        VTK_BUILD: "  - vtk=*=osmesa_*"
       run: |
         tox -e ${{ matrix.version }}-lock
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request renders the `conda` lock-files with the osmesa `vtk` build, rather than qt.

---
