### PR TITLE
NEP29 compliance drop schedule for numpy

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -13,7 +13,7 @@ dependencies:
   - cartopy >=0.22
   - click
   - click-default-group
-  - numpy >=1.21
+  - numpy >1.21
   - platformdirs
   - pooch
   - pykdtree

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -3,7 +3,7 @@ click
 click-default-group
 cmocean
 netCDF4
-numpy>=1.21
+numpy>1.21
 platformdirs
 pooch
 pykdtree


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR adopts the [NEP29 Drop Schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) for minimum supported versions of `numpy`.

---
