### PR TITLE
tox pre-create pytest-pyvista test images directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ skip_install =
 [testenv:py{39,310,311}-tests]
 allowlist_externals =
     Xvfb
+    mkdir
 conda_spec =
     py39: {toxinidir}{/}requirements{/}locks{/}py39-lock-linux-64.txt
     py310: {toxinidir}{/}requirements{/}locks{/}py310-lock-linux-64.txt
@@ -65,6 +66,7 @@ passenv =
 usedevelop =
     true
 commands =
+    mkdir --parents {toxinidir}/test_images
     pytest {posargs} --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images
     {env:POST_COMMAND:}
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR creates the `pytest-pyvista` generated images test directory prior to calling `pytest` in order to avoid the following warning `UserWarning: pyvista test generated image dir: /home/runner/work/geovista/geovista/test_images does not yet exist.  Creating dir.`

Ping @tkoyama010 

---
