### PR TITLE
Elevate tox pytest warnings to errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ usedevelop =
     true
 commands =
     mkdir --parents {toxinidir}/test_images
-    pytest {posargs} --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images
+    pytest {posargs} -W error --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images
     {env:POST_COMMAND:}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ usedevelop =
     true
 commands =
     mkdir --parents {toxinidir}/test_images
-    pytest {posargs} -W error --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images
+    pytest {posargs} --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images -W error -W "ignore:numpy.ndarray size changed:RuntimeWarning"
     {env:POST_COMMAND:}
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces the same level of strictness as the `pyvista` integration testing of `geovista` by elevating `warnings` to `errors` under `pytest`, see [here](https://github.com/pyvista/pyvista/blob/main/.github/workflows/integration-tests.yml#L104).

This is to ensure that the `main` branch of `geovista` doesn't break the `pyvista` CI due to warnings being issued during `geovista` testing. 

---
