### PR TITLE
Use pytest filterwarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,14 +78,25 @@ skip = ".git,*.ipynb"
 
 
 [tool.pytest.ini_options]
-addopts = "-ra -v --doctest-modules --doctest-continue-on-failure --import-mode=importlib --strict-markers"
+addopts = [
+    "--doctest-continue-on-failure",
+    "--doctest-modules",
+    "--import-mode=importlib",
+    "-ra",
+    "--strict-markers",
+    "-v",
+]
+doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS NUMBER"
+filterwarnings = [
+    "error",
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
+]
+image_cache_dir = "tests/plotting/image_cache"
 markers = [
     "image: plotter rendering image test",
 ]
 minversion = "6.0"
-doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS NUMBER"
 testpaths = "tests"
-image_cache_dir = "tests/plotting/image_cache"
 
 
 [tool.ruff]

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ usedevelop =
     true
 commands =
     mkdir --parents {toxinidir}/test_images
-    pytest {posargs} --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images -W error -W "ignore:numpy.ndarray size changed:RuntimeWarning"
+    pytest {posargs} --fail_extra_image_cache --generated_image_dir {toxinidir}{/}test_images
     {env:POST_COMMAND:}
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces `warnings` escalation to `error` when `pytest` is invoked either through CI or the CLI through the use of the `pytest` [filterwarings](https://docs.pytest.org/en/7.1.x/reference/reference.html#confval-filterwarnings) option.

---
