### PR TITLE
Drop pytest-xdist

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -37,7 +37,6 @@ dependencies:
   - pytest-cov
   - pytest-mock
   - pytest-pyvista
-  - pytest-xdist
   - pytest-xvfb
 
 # examples dependencies (optional)

--- a/requirements/pypi-optional-test.txt
+++ b/requirements/pypi-optional-test.txt
@@ -4,5 +4,4 @@ pytest>=6.0
 pytest-cov
 pytest-mock
 pytest-pyvista
-pytest-xdist
 pytest-xvfb


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Using `pytest-xdist` and `netCDF4` is not a good mix, as `netCDF4` is not thread-safe.

---
