### PR TITLE
add uber-h3 optional dependencies

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -41,6 +41,7 @@ dependencies:
 
 # examples dependencies (optional)
   - fastparquet
+  - h3-py
   - pandas
 
 # documentation dependencies (optional)

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,2 +1,3 @@
 fastparquet
+h3
 pandas


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR adds the optional [Uber H3](https://github.com/uber/h3) package dependency to support forthcoming new example of using the hexagonal hierarchical spatial index.

---
