### PR TITLE
adopt py310 typing

### DIFF
--- a/src/geovista/cache.py
+++ b/src/geovista/cache.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from importlib.resources import files
 import os
-from typing import Union
 
 import pooch
 import pyvista as pv
@@ -29,7 +28,7 @@ __all__ = [
 ]
 
 # Type aliases.
-TextureLike = Union[str, pv.Texture]
+TextureLike = str | pv.Texture
 
 #: Base URL for geovista resources.
 BASE_URL: str = "https://github.com/bjlittle/geovista-data/raw/{version}/data/"

--- a/src/geovista/crs.py
+++ b/src/geovista/crs.py
@@ -7,8 +7,6 @@ Notes
 """
 from __future__ import annotations
 
-from typing import Union
-
 import numpy as np
 from pyproj import CRS
 import pyvista as pv
@@ -28,7 +26,7 @@ __all__ = [
 ]
 
 # type aliases
-CRSLike = Union[int, str, dict, CRS]
+CRSLike = int | str | dict | CRS
 
 #: EPSG projection parameter for longitude of natural origin/central meridian
 EPSG_CENTRAL_MERIDIAN: str = "8802"

--- a/src/geovista/examples/uber_h3.py
+++ b/src/geovista/examples/uber_h3.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import combinations
 from pathlib import Path
-from typing import Union
 
 try:
     import h3
@@ -36,7 +35,7 @@ import geovista.theme
 MDI = -1
 
 #: Type alias
-H3AssetLike = Union[str, PolyData]
+H3AssetLike = str | PolyData
 H3Indexes = set[str]
 
 

--- a/src/geovista/report.py
+++ b/src/geovista/report.py
@@ -8,7 +8,6 @@ Notes
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Union
 
 import pyvista
 import scooby
@@ -16,7 +15,7 @@ import scooby
 __all__ = ["Report"]
 
 # type aliases
-PackageLike = Union[ModuleType, str]
+PackageLike = ModuleType | str
 
 #: Default number of package columns in report HTML table.
 NCOL: int = 3

--- a/src/geovista/search.py
+++ b/src/geovista/search.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from enum import Enum
-from typing import Union
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -24,7 +23,7 @@ __all__ = ["KDTree", "Preference", "find_cell_neighbours", "find_nearest_cell"]
 
 # type aliases
 CellIDs = list[int]
-CellIDLike = Union[int, CellIDs]
+CellIDLike = int | CellIDs
 NearestNeighbours = tuple[ArrayLike, ArrayLike]
 
 #: The default kd-tree nearest neighbour epsilon.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The minimum supported version of Python is 3.10, therefore it is now safe to replace `typing.Union` syntax with `|` instead.

---
