### PR TITLE
drop explicit pep517 wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@
 requires = [
     "setuptools>=61",
     "setuptools_scm[toml]>=7",
-    "wheel"
 ]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

It is not necessary to explicitly include `wheel` in the `build-system.requires`, as `setuptools` backend does this via PEP517.

For an explanation, see https://github.com/pypa/setuptools/pull/3859

---
