### PR TITLE
adopt pytest xfail-strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ markers = [
 minversion = "6.0"
 required_plugins = "pytest-mock pytest_pyvista"
 testpaths = "tests"
+xfail_strict = "True"
 
 
 [tool.ruff]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adopts `xfail_strict = True` for `pytest` to catch expected failures that succeed i.e., unexpectedly pass rather than fail as expected.

---
