### PR TITLE
auto-label 'skip changelog'

### DIFF
--- a/.github/workflows/ci-label.yml
+++ b/.github/workflows/ci-label.yml
@@ -53,3 +53,8 @@ jobs:
         if: startsWith(github.event.pull_request.head.ref, 'perf') || startsWith(github.event.pull_request.head.ref, 'performance')
         with:
           labels: 'type: performance'
+
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: startsWith(github.event.pull_request.head.ref, 'pre-commit-ci-update-config') || startsWith(github.event.pull_request.head.ref, 'conda-lock-auto-update')
+        with:
+          labels: 'skip changelog'


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request auto-labels bot generated pull-requests from `pre-commit.ci` and `conda-lock` updates, which don't require associated change-log entries to be enforced.

This is in preparation of forthcoming CI bot verification of pull-requests containing `towncrier` new fragments for the release change-log.  

---
