### PR TITLE
enforce ruff D212 pydocstyle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,10 @@ ignore = [
 preview = false
 select = [
     "ALL",
+
+    # pydocstyle (D)
+    # https://docs.astral.sh/ruff/rules/multi-line-summary-first-line/
+    "D212",  # Multi-line docstring summary should start at the first line
 ]
 
 

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -56,8 +56,7 @@ NAME_POINTS: str = "point_data"
 
 
 class Transform:
-    """
-    Build a mesh from spatial points, connectivity, data and CRS metadata.
+    """Build a mesh from spatial points, connectivity, data and CRS metadata.
 
     Notes
     -----

--- a/src/geovista/examples/point_cloud/from_points__orca_cloud.py
+++ b/src/geovista/examples/point_cloud/from_points__orca_cloud.py
@@ -21,7 +21,7 @@ area and pre-filtered for temperature gradients.
 Note that, Natural Earth coastlines are also rendered along with a Natural
 Earth base layer with opacity.
 
-"""  # noqa: D205,D400
+"""  # noqa: D205,D212,D400
 from __future__ import annotations
 
 import geovista as gv

--- a/src/geovista/examples/point_cloud/from_points__orca_cloud_eqc.py
+++ b/src/geovista/examples/point_cloud/from_points__orca_cloud_eqc.py
@@ -23,7 +23,7 @@ Earth base layer with opacity. Additionally, the mesh is transformed to
 the Equidistant Cylindrical (Plate Carrée) conformal cylindrical
 projection.
 
-"""  # noqa: D205,D400
+"""  # noqa: D205,D212,D400
 from __future__ import annotations
 
 import geovista as gv
@@ -33,8 +33,7 @@ import geovista.theme
 
 
 def main() -> None:
-    """
-    Plot a projected point cloud.
+    """Plot a projected point cloud.
 
     Notes
     -----

--- a/src/geovista/examples/vector_data/vectors.py
+++ b/src/geovista/examples/vector_data/vectors.py
@@ -16,7 +16,7 @@ regular quad-cell sample grid.
 
 A Natural Earth base layer is also rendered.
 
-"""  # noqa: D205,D400
+"""  # noqa: D205,D212,D400
 from __future__ import annotations
 
 import numpy as np


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces the [D212](https://docs.astral.sh/ruff/rules/multi-line-summary-first-line/) multi-line docstring summary should start at the first line, which is automatically disabled when `convention = "numpy"` for `pydocstyle` (which it is). 

---
