### PR TITLE
add cli download decompress option

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
       - git fetch --unshallow
       - git fetch --all
     post_install:
-      - geovista download --all
+      - geovista download --all --decompress
 
 conda:
   environment: requirements/geovista.yml


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds the `-d | --decompress` flag to the `geovista download` CLI to force asset decompression after download.

This flag is then used to decompress all assets prior to building the documentation, thus avoiding the decompression cost during documentation building. 

---
