### PR TITLE
rename Preference enumeration classes

### DIFF
--- a/src/geovista/geodesic.py
+++ b/src/geovista/geodesic.py
@@ -38,8 +38,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BBox",
+    "EnclosedPreference",
     "GEODESIC_NPTS",
-    "Preference",
     "line",
     "npoints",
     "npoints_by_idx",
@@ -106,8 +106,8 @@ PREFERENCE: str = "center"
 
 
 # TODO @bjlittle: Use StrEnum and auto when minimum supported python version is 3.11.
-class Preference(_MixinStrEnum, Enum):
-    """Enumeration of geodesic mesh geometry preferences.
+class EnclosedPreference(_MixinStrEnum, Enum):
+    """Enumeration of mesh geometry enclosed preferences.
 
     Notes
     -----
@@ -515,7 +515,7 @@ class BBox:
         surface: pv.PolyData,
         tolerance: float | None = BBOX_TOLERANCE,
         outside: bool | None = False,
-        preference: str | Preference | None = None,
+        preference: str | EnclosedPreference | None = None,
     ) -> pv.PolyData:
         """Extract region of the `surface` contained within the bounding-box.
 
@@ -534,7 +534,7 @@ class BBox:
             By default, select those points of the `surface` that are inside
             the bounding-box. Otherwise, select those points that are outside
             the bounding-box.
-        preference : str or Preference, optional
+        preference : str or EnclosedPreference, optional
             Criteria for defining whether a face of a `surface` mesh is
             deemed to be enclosed by the bounding-box. A `preference` of
             ``cell`` requires all points defining the face to be within the
@@ -558,15 +558,15 @@ class BBox:
         if preference is None:
             preference = PREFERENCE
 
-        if not Preference.valid(preference):
-            options = " or ".join(f"{item!r}" for item in Preference.values())
+        if not EnclosedPreference.valid(preference):
+            options = " or ".join(f"{item!r}" for item in EnclosedPreference.values())
             emsg = f"Expected a preference of {options}, got '{preference}'."
             raise ValueError(emsg)
 
-        preference = Preference(preference)
+        preference = EnclosedPreference(preference)
         self._generate_bbox_mesh(surface=surface)
 
-        if preference == Preference.CENTER:
+        if preference == EnclosedPreference.CENTER:
             original = surface
             surface = surface.cell_centers()
 
@@ -578,9 +578,9 @@ class BBox:
         scalars = "SelectedPoints"
 
         # sample the surface with the enclosed cells to extract the bbox region
-        if preference == Preference.CENTER:
+        if preference == EnclosedPreference.CENTER:
             region = original.extract_cells(selected[scalars].view(bool))
-        elif preference == Preference.POINT:
+        elif preference == EnclosedPreference.POINT:
             region = selected.threshold(0.5, scalars=scalars, preference="cell")
         else:
             region = surface.extract_points(

--- a/src/geovista/search.py
+++ b/src/geovista/search.py
@@ -27,7 +27,7 @@ from .transform import transform_points
 if TYPE_CHECKING:
     from pyvista import PolyData
 
-__all__ = ["KDTree", "Preference", "find_cell_neighbours", "find_nearest_cell"]
+__all__ = ["KDTree", "SearchPreference", "find_cell_neighbours", "find_nearest_cell"]
 
 # type aliases
 CellIDs = list[int]
@@ -48,8 +48,8 @@ KDTREE_PREFERENCE: str = "point"
 
 
 # TODO @bjlittle: Use StrEnum and auto when minimum supported python version is 3.11.
-class Preference(_MixinStrEnum, Enum):
-    """Enumeration of mesh geometry preferences.
+class SearchPreference(_MixinStrEnum, Enum):
+    """Enumeration of mesh geometry search preferences.
 
     Notes
     -----
@@ -76,7 +76,7 @@ class KDTree:
         self,
         mesh: PolyData,
         leaf_size: int | None = None,
-        preference: str | Preference | None = None,
+        preference: str | SearchPreference | None = None,
     ) -> None:
         """Construct kd-tree for nearest neighbour search of mesh points/cell centers.
 
@@ -99,9 +99,9 @@ class KDTree:
             of the kd-tree. Increasing the leaf size will reduce the memory overhead and
             construction time, but increase the query time. Defaults to
             :data:`KDTREE_LEAF_SIZE`.
-        preference : str or Preference, optional
+        preference : str or SearchPreference, optional
             Construct the kd-tree from the `mesh` points ``point`` or cell centers
-            ``center``. Also see :class:`Preference`. Defaults to
+            ``center``. Also see :class:`SearchPreference`. Defaults to
             :data:`KDTREE_PREFERENCE`.
 
         Notes
@@ -117,15 +117,15 @@ class KDTree:
         if preference is None:
             preference = KDTREE_PREFERENCE
 
-        if not Preference.valid(preference):
-            options = " or ".join(f"{item!r}" for item in Preference.values())
+        if not SearchPreference.valid(preference):
+            options = " or ".join(f"{item!r}" for item in SearchPreference.values())
             emsg = f"Expected a preference of {options}, got '{preference}'."
             raise ValueError(emsg)
 
-        self._preference = Preference(preference)
+        self._preference = SearchPreference(preference)
         xyz = (
             mesh.points
-            if self._preference == Preference.POINT
+            if self._preference == SearchPreference.POINT
             else mesh.cell_centers().points
         )
         crs = from_wkt(mesh)
@@ -205,14 +205,14 @@ class KDTree:
         return self._kdtree.data.reshape(-1, 3).copy()
 
     @property
-    def preference(self) -> Preference:
+    def preference(self) -> SearchPreference:
         """The target mesh geometry to search.
 
         Focus either on the mesh points or the mesh cell centers.
 
         Returns
         -------
-        Preference
+        SearchPreference
             The preference of mesh geometry to search.
 
         Notes

--- a/tests/geodesic/test_BBox.py
+++ b/tests/geodesic/test_BBox.py
@@ -17,7 +17,7 @@ from geovista.common import (
     distance,
 )
 from geovista.crs import WGS84, from_wkt
-from geovista.geodesic import PANEL_IDX_BY_NAME, BBox, Preference, panel
+from geovista.geodesic import PANEL_IDX_BY_NAME, BBox, EnclosedPreference, panel
 
 from .conftest import CIDS
 
@@ -29,7 +29,9 @@ C48 = (48, 48)
 
 
 @pytest.mark.parametrize("outside", [False, True])
-@pytest.mark.parametrize("preference", ["point", Preference.POINT, Preference("point")])
+@pytest.mark.parametrize(
+    "preference", ["point", EnclosedPreference.POINT, EnclosedPreference("point")]
+)
 def test_enclosed_point(antarctic_corners, lfric_sst, outside, preference):
     """Test enclosed points of antarctic cubed-sphere panel."""
     lons, lats = antarctic_corners
@@ -46,7 +48,9 @@ def test_enclosed_point(antarctic_corners, lfric_sst, outside, preference):
 
 
 @pytest.mark.parametrize("outside", [False, True])
-@pytest.mark.parametrize("preference", ["cell", Preference.CELL, Preference("cell")])
+@pytest.mark.parametrize(
+    "preference", ["cell", EnclosedPreference.CELL, EnclosedPreference("cell")]
+)
 def test_enclosed_cell(antarctic_corners, lfric_sst, outside, preference):
     """Test enclosed cells of antarctic cubed-sphere panel."""
     lons, lats = antarctic_corners
@@ -63,7 +67,8 @@ def test_enclosed_cell(antarctic_corners, lfric_sst, outside, preference):
 
 @pytest.mark.parametrize("outside", [False, True])
 @pytest.mark.parametrize(
-    "preference", [None, "center", Preference.CENTER, Preference("center")]
+    "preference",
+    [None, "center", EnclosedPreference.CENTER, EnclosedPreference("center")],
 )
 def test_enclosed_center(lfric_sst, outside, preference):
     """Test enclosed centers of antarctic cubed-sphere panel."""

--- a/tests/geodesic/test_EnclosedPreference.py
+++ b/tests/geodesic/test_EnclosedPreference.py
@@ -3,29 +3,29 @@
 # This file is part of GeoVista and is distributed under the 3-Clause BSD license.
 # See the LICENSE file in the package root directory for licensing details.
 
-"""Unit-tests for :class:`geovista.geodesic.Preference`."""
+"""Unit-tests for :class:`geovista.geodesic.EnclosedPreference`."""
 from __future__ import annotations
 
 import pytest
 
-from geovista.geodesic import Preference
+from geovista.geodesic import EnclosedPreference
 
 EXPECTED_VALUES: tuple[str, str] = ("cell", "center", "point")
 
 
 def test_member_count():
     """Test expected number of enumeration members."""
-    assert len(Preference) == 3
+    assert len(EnclosedPreference) == 3
 
 
 def test_members():
     """Test expected enumeration members."""
-    assert tuple([member.value for member in Preference]) == EXPECTED_VALUES
+    assert tuple([member.value for member in EnclosedPreference]) == EXPECTED_VALUES
 
 
 def test_values():
     """Test expected enumeration member values."""
-    assert Preference.values() == EXPECTED_VALUES
+    assert EnclosedPreference.values() == EXPECTED_VALUES
 
 
 @pytest.mark.parametrize(
@@ -49,10 +49,10 @@ def test_values():
 )
 def test_valid_members(member, expected):
     """Test valid enumeration members."""
-    assert Preference.valid(member) is expected
+    assert EnclosedPreference.valid(member) is expected
     if expected:
-        assert Preference(member).value == member.lower()
+        assert EnclosedPreference(member).value == member.lower()
     else:
-        emsg = f"{member!r} is not a valid Preference"
+        emsg = f"{member!r} is not a valid EnclosedPreference"
         with pytest.raises(ValueError, match=emsg):
-            _ = Preference(member)
+            _ = EnclosedPreference(member)

--- a/tests/search/test_KDTree.py
+++ b/tests/search/test_KDTree.py
@@ -13,9 +13,14 @@ import pyvista as pv
 
 from geovista.common import GV_FIELD_CRS, from_cartesian
 from geovista.crs import WGS84, to_wkt
-from geovista.search import KDTREE_LEAF_SIZE, KDTREE_PREFERENCE, KDTree, Preference
+from geovista.search import (
+    KDTREE_LEAF_SIZE,
+    KDTREE_PREFERENCE,
+    KDTree,
+    SearchPreference,
+)
 
-PREFERENCES = Preference.values()
+PREFERENCES = SearchPreference.values()
 
 
 def test_defaults(lam_uk):
@@ -42,7 +47,7 @@ def test_preference(lam_uk, preference):
     kdtree = KDTree(lam_uk, preference=preference)
     n_points = (
         lam_uk.n_cells
-        if Preference(preference) == Preference.CENTER
+        if SearchPreference(preference) == SearchPreference.CENTER
         else lam_uk.n_points
     )
     assert kdtree.n_points == n_points
@@ -50,7 +55,7 @@ def test_preference(lam_uk, preference):
 
 def test_preference_fail(lam_uk):
     """Test trap of invalid preference."""
-    options = " or ".join([f"{item!r}" for item in Preference.values()])
+    options = " or ".join([f"{item!r}" for item in SearchPreference.values()])
     emsg = f"Expected a preference of {options}"
     with pytest.raises(ValueError, match=emsg):
         _ = KDTree(lam_uk, preference="invalid")
@@ -65,7 +70,7 @@ def test_missing_crs(lam_uk, preference):
     kdtree = KDTree(lam_uk, preference=preference)
     expected = (
         lam_uk.points
-        if Preference(preference) == Preference.POINT
+        if SearchPreference(preference) == SearchPreference.POINT
         else lam_uk.cell_centers().points
     )
     np.testing.assert_array_almost_equal(kdtree.points, expected)
@@ -76,7 +81,7 @@ def test_crs_eqc(lam_uk, preference):
     """Test kd-tree CRS transformation."""
     lam_xyz = (
         lam_uk.points
-        if Preference(preference) == Preference.POINT
+        if SearchPreference(preference) == SearchPreference.POINT
         else lam_uk.cell_centers().points
     )
     lam_lonlat = from_cartesian(pv.PolyData(lam_xyz))

--- a/tests/search/test_SearchPreference.py
+++ b/tests/search/test_SearchPreference.py
@@ -3,29 +3,29 @@
 # This file is part of GeoVista and is distributed under the 3-Clause BSD license.
 # See the LICENSE file in the package root directory for licensing details.
 
-"""Unit-tests for :class:`geovista.search.Preference`."""
+"""Unit-tests for :class:`geovista.search.SearchPreference`."""
 from __future__ import annotations
 
 import pytest
 
-from geovista.search import Preference
+from geovista.search import SearchPreference
 
 EXPECTED_VALUES: tuple[str, str] = ("center", "point")
 
 
 def test_member_count():
     """Test expected number of enumeration members."""
-    assert len(Preference) == 2
+    assert len(SearchPreference) == 2
 
 
 def test_members():
     """Test expected enumeration members."""
-    assert tuple([member.value for member in Preference]) == EXPECTED_VALUES
+    assert tuple([member.value for member in SearchPreference]) == EXPECTED_VALUES
 
 
 def test_values():
     """Test expected enumeration member values."""
-    assert Preference.values() == EXPECTED_VALUES
+    assert SearchPreference.values() == EXPECTED_VALUES
 
 
 @pytest.mark.parametrize(
@@ -45,10 +45,10 @@ def test_values():
 )
 def test_valid_members(member, expected):
     """Test valid enumeration members."""
-    assert Preference.valid(member) is expected
+    assert SearchPreference.valid(member) is expected
     if expected:
-        assert Preference(member).value == member.lower()
+        assert SearchPreference(member).value == member.lower()
     else:
-        emsg = f"{member!r} is not a valid Preference"
+        emsg = f"{member!r} is not a valid SearchPreference"
         with pytest.raises(ValueError, match=emsg):
-            _ = Preference(member)
+            _ = SearchPreference(member)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request provides namespace distinction for the `Preference` enumeration classes within `geovista.common`, `geovista.geodesic` and `geovista.search`, by renaming the classes for clarity.

In addition, it will side step the following `autoapi` generated warning (see #615):

```
 WARNING: more than one target found for cross-reference 'Preference': geovista.common.Preference, geovista.geodesic.Preference, geovista.search.Preference
```

---
