### PR TITLE
bump pyvista min pin

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -18,7 +18,7 @@ dependencies:
   - pooch
   - pykdtree
   - pyproj >=3.3
-  - pyvista >=0.40
+  - pyvista >=0.43.1
 
 # pantry dependencies
   - netcdf4

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -8,4 +8,4 @@ platformdirs
 pooch
 pykdtree
 pyproj>=3.3
-pyvista>=0.40
+pyvista>=0.43.1


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request bumps the minimum pin for `pyvista`, which on `main` ([74142c4](https://github.com/bjlittle/geovista/commit/74142c44dd15d8f4ab26466616f8cf3be543d088)) is currently restricted to `pyvista >=0.40,<0.42.2` due to a breaking behaviour in `pyvista=0.42.2`, see #447 for details.

There is now a `geovista` fix that will resolve #447, thus allowing `geovista` to use the latest version of `pyvista`. This fix is forthcoming and will result in the `0.4.1` patch release from the `0.4.x` release feature branch.

Before the `0.4.1` patch can be released, we require to update the `lock` dependencies, apply the fix and deal with new deprecation's being issued from the latest version of `pyvista`.

> [!NOTE]
> The docs are not yet building for `0.4.x`.
> The work to bootstrap the docs happened on `main` post `0.4.0` and the `0.4.x` release branch.
> i.e., it's okay to merge this pull-request with the failing CI RTD job

---
