### PR TITLE
fix active_t_coords deprecation

### DIFF
--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -305,7 +305,7 @@ def add_texture_coords(
     u_coord = (lons + 180) / 360
     v_coord = (lats + 90) / 180
     t_coord = np.vstack([u_coord, v_coord]).T
-    mesh.active_t_coords = t_coord
+    mesh.active_texture_coordinates = t_coord
 
     return mesh
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request addresses the following `pyvista` deprecation warning:

```bash
PyVistaDeprecationWarning: Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.
```

---
