### PR TITLE
disable docs navigation with keys

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -222,6 +222,7 @@ html_theme_options = {
             "icon": "fa-brands fa-twitter",
         },
     ],
+    "navigation_with_keys": False,
     "path_to_docs": "docs/src",
     "repository_branch": "main",
     "repository_url": "https://github.com/bjlittle/geovista",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request addresses the following `sphinx-book-theme` warning by disabling
navigation with keys, as recommended.

```
The default value for `navigation_with_keys` will change to `False` in the next release.
If you wish to preserve the old behavior for your site, set `navigation_with_keys=True`
in the `html_theme_options` dict in your `conf.py` file.
Be aware that `navigation_with_keys = True` has negative accessibility implications:
https://github.com/pydata/pydata-sphinx-theme/issues/1492
```
---
