### PR TITLE
add auto label for merge-back

### DIFF
--- a/.github/workflows/ci-label.yml
+++ b/.github/workflows/ci-label.yml
@@ -58,3 +58,8 @@ jobs:
         if: github.actor == 'dependabot[bot]' || github.actor == 'geovista-ci[bot]' || github.actor == 'pre-commit-ci[bot]'
         with:
           labels: 'skip changelog'
+
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: startsWith(github.event.pull_request.head.ref, 'merge-back') || startsWith(github.event.pull_request.head.ref, 'mb')
+        with:
+          labels: 'type: merge-back'


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request extends the auto labeler GHA to label merge back feature branches to `main`.

---
