### PR TITLE
docs default pygments highlight with andmonish

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -176,8 +176,15 @@ language = "en"
 
 # -- pygments options --------------------------------------------------------
 # See https://pygments.org/styles/
+# See https://pygments.org/docs/lexers/#lexers-for-python-and-related-languages
 
 # The name of the Pygments (syntax highlighting) style to use.
+highlight_language = "python"
+highlight_options = {
+    "default": "python",
+    "bash": "powershell",
+    "python": "python",
+}
 pygments_style = "friendly"
 
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -5,13 +5,14 @@ GeoVista Documentation
 
 Welcome to the GeoVista documentation!
 
-.. margin:: **Under Construction**
+.. note::
+    :class: margin
 
     We've marked content with a 🚧 to indicate that it's still under construction.
 
 We're busily crafting the structure and content of the documentation,
 so it's likely that some material will change, move around or even be removed.  However,
-the dust will settle and we'll eventually have a solid foundation to build upon.  Thanks
+the dust will eventually settle and we'll have a stable foundation to build upon.  Thanks
 for your patience.
 
 In the meantime, your feedback is important to us.  So feel free to submit a GitHub

--- a/src/geovista/examples/README.rst
+++ b/src/geovista/examples/README.rst
@@ -7,14 +7,15 @@ Examples Gallery
 This interactive gallery highlights the growing capabilities and
 features of ``geovista``.
 
+.. role:: bash(code)
+    :language: bash
+
 The gallery is generated from the ``geovista.examples``, which can also
-be run from the command line::
+be run from the command line with :bash:`geovista examples --all --verbose`.
 
-  geovista examples --run all --verbose
+.. note::
+  :class: margin
 
-.. only:: on_rtd
-
-  .. note::
-    Title text and graticule labels will **not** be rendered when viewing the
-    documentation on ``ReadtheDocs``, as they are not supported in this
-    headless environment.
+  The gallery `vtk.js <https://kitware.github.io/vtk-js/index.html>`_
+  **Interactive Scene** backend does **not** support text rendering,
+  or points as spheres.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request sets the default documentation code highlighting to the `python` `pygments`  lexer, and tweaks the gallery admonish to use the `sphinx-book-theme` `margin` sidebar lovliness.

---
