### PR TITLE
add examples pyarrow optional dependancy

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -43,6 +43,7 @@ dependencies:
   - fastparquet
   - h3-py
   - pandas
+  - pyarrow
 
 # documentation dependencies (optional)
   - jupyter_sphinx

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,3 +1,4 @@
 fastparquet
 h3
 pandas
+pyarrow


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request explicitly adds the optional dependency `pyarrow` for the `geovista.examples.scalar_data` examples.

This is to avoid the following `DeprecationWarning` being issued by the recently released `pandas` 2.2.0:

```
DeprecationWarning: 
Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
but was not found to be installed on your system.
If this would cause problems for you,
please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```

See #656.

---
