### PR TITLE
avoid pyvista polydata deprecation warning

### DIFF
--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -847,7 +847,7 @@ class Transform:
             )
 
         # create the mesh
-        mesh = pv.PolyData(geometry, faces=faces, n_faces=n_faces)
+        mesh = pv.PolyData(geometry, faces=faces)
 
         # attach the pyproj crs serialized as ogc wkt
         to_wkt(mesh, WGS84)

--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -363,7 +363,7 @@ def combine(
 
     first: pv.PolyData = meshes[0]
     combined_points, combined_faces = [], []
-    n_points, n_faces = 0, 0
+    n_points = 0
 
     if data:
         # determine the common point, cell and field array names
@@ -415,7 +415,6 @@ def combine(
         combined_faces.append(faces)
         # accumulate running totals of combined mesh points and cells
         n_points += mesh.n_points
-        n_faces += mesh.n_cells
 
         if data:
             # perform intersection to determine common names
@@ -427,7 +426,7 @@ def combine(
 
     points = np.vstack(combined_points)
     faces = np.hstack(combined_faces)
-    combined = pv.PolyData(points, faces=faces, n_faces=n_faces)
+    combined = pv.PolyData(points, faces=faces)
 
     def combine_data(names: set[str], field: bool | None = False) -> None:
         for name in names:

--- a/src/geovista/geodesic.py
+++ b/src/geovista/geodesic.py
@@ -430,10 +430,9 @@ class BBox:
 
             # include the bbox skirt
             bbox_faces = np.vstack([bbox_faces, skirt_faces])
-            bbox_n_faces += skirt_faces.shape[0]
 
             # create the bbox mesh
-            self._mesh = pv.PolyData(bbox_xyz, faces=bbox_faces, n_faces=bbox_n_faces)
+            self._mesh = pv.PolyData(bbox_xyz, faces=bbox_faces)
 
             self._mesh.field_data[GV_FIELD_RADIUS] = np.array([radius])
             to_wkt(self._mesh, WGS84)

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -311,7 +311,7 @@ def create_meridians(
         lines[:, 1] = np.arange(n_points)
         lines[:, 2] = np.arange(n_points) + 1
 
-        mesh = pv.PolyData(xyz, lines=lines, n_lines=n_points)
+        mesh = pv.PolyData(xyz, lines=lines)
         to_wkt(mesh, WGS84)
 
         if closed_interval and mask[index]:
@@ -512,7 +512,7 @@ def create_parallels(
         lines[:, 2] = np.arange(n_points) + 1
         lines[-1, 2] = 0
 
-        mesh = pv.PolyData(xyz, lines=lines, n_lines=n_points)
+        mesh = pv.PolyData(xyz, lines=lines)
         to_wkt(mesh, WGS84)
         blocks[f"{index},{lat!r}"] = mesh
         grid_lats.append(lat)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request avoids the `PolyData` deprecation warning that will be introduced to the `main` branch of `pyvista` with pull-request https://github.com/pyvista/pyvista/pull/5495.

On `pyvista`, integration tests include testing a `pyvista` pull-request branch against the `main` branch of `geovista`. Pull-requests that introduce new deprecation warnings may result in an integration test failure from downstream third-party packages, as `pytest` is configure to escalate warnings to errors on `pyvista`.

Going forwards, we require to either:

- address these failures when notified by the `pyvista` core developers or the pull-request author by changing the `geovista` code-base appropriately
- if the previous step is not possible, then introduce the new deprecation warning to the `filterwarnings` configuration section of `pytest` in the `pyproject.toml`. Create an issue capturing this, then on release of `pyvista` introduce a min pin, remove the warning from `filterwarnings`, and change the code-base appropriately. 

---
