### PR TITLE
add lazy_loader core package dependency

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -13,6 +13,7 @@ dependencies:
   - cartopy >=0.22
   - click
   - click-default-group
+  - lazy_loader
   - numpy >=1.23
   - platformdirs
   - pooch

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -2,6 +2,7 @@ cartopy>=0.22
 click
 click-default-group
 cmocean
+lazy_loader
 netCDF4
 numpy>=1.23
 platformdirs


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds the [lazy_loader](https://github.com/scientific-python/lazy_loader) as a core package, which supports the lazy `import` of external packages and internal submodules.

The `lazy_loader` underpins the solution to addressing issue #647. 

---
