### PR TITLE
support lazy import

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ prune .tox
 prune docs
 prune requirements
 recursive-include requirements pypi-*.txt
-recursive-include src *.py *.rst *.txt *.md
+recursive-include src *.md *.py *.pyi *.rst *.txt
 prune tests
 
 include .git_archival.txt

--- a/src/geovista/__init__.py
+++ b/src/geovista/__init__.py
@@ -24,29 +24,15 @@ from __future__ import annotations
 
 import os
 
-from .bridge import Transform  # noqa: F401
-from .common import vtk_warnings_off, vtk_warnings_on  # noqa: F401
-from .core import slice_cells, slice_lines  # noqa: F401
-from .crs import from_wkt, to_wkt  # noqa: F401
-from .geodesic import BBox, line, panel, wedge  # noqa: F401
-from .geometry import coastlines  # noqa: F401
-from .geoplotter import GeoPlotter  # noqa: F401
-from .pantry import fetch_coastlines  # noqa: F401
-from .pantry.textures import (  # noqa: F401
-    blue_marble,
-    checkerboard,
-    natural_earth_1,
-    natural_earth_hypsometric,
-)
-from .report import Report  # noqa: F401
+import lazy_loader as lazy
+
+# lazy import submodules
+(__getattr__, __dir__, __all__) = lazy.attach_stub(__name__, __file__)
 
 try:
     from ._version import version as __version__
 except ModuleNotFoundError:
     __version__ = "unknown"
-
-# let's assume this is a sane default to adopt
-vtk_warnings_off()
 
 #: flag when performing image testing
 GEOVISTA_IMAGE_TESTING: bool = (

--- a/src/geovista/__init__.pyi
+++ b/src/geovista/__init__.pyi
@@ -1,0 +1,25 @@
+# see https://scientific-python.org/specs/spec-0001/#type-checkers
+from .bridge import Transform
+from .geodesic import BBox, line, panel, wedge
+from .geoplotter import GeoPlotter
+from .pantry.textures import (
+    blue_marble,
+    checkerboard,
+    natural_earth_1,
+    natural_earth_hypsometric,
+)
+from .report import Report
+
+__all__ = [
+    "BBox",
+    "GeoPlotter",
+    "Report",
+    "Transform",
+    "blue_marble",
+    "checkerboard",
+    "line",
+    "natural_earth_1",
+    "natural_earth_hypsometric",
+    "panel",
+    "wedge",
+]

--- a/src/geovista/cli.py
+++ b/src/geovista/cli.py
@@ -18,8 +18,7 @@ from shutil import rmtree
 
 import click
 from click_default_group import DefaultGroup
-import pooch
-import pyvista as pv
+import lazy_loader as lazy
 
 from ._version import version as __version__
 from .cache import CACHE, GEOVISTA_POOCH_MUTE, pooch_mute
@@ -27,6 +26,10 @@ from .common import get_modules
 from .config import resources
 from .geoplotter import GeoPlotter
 from .report import Report
+
+# lazy import third-party dependencies
+pooch = lazy.load("pooch")
+pv = lazy.load("pyvista")
 
 __all__ = ["main"]
 

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -19,15 +19,17 @@ import pkgutil
 import sys
 from typing import TYPE_CHECKING
 
-import numpy as np
-from numpy import ma
-import pyvista as pv
-from pyvista import _vtk
-from pyvista.core.filters import _get_output
-from vtk import vtkLogger, vtkObject
+import lazy_loader as lazy
 
 if TYPE_CHECKING:
+    import numpy as np
     from numpy.typing import ArrayLike
+    import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pv = lazy.load("pyvista")
+vtk = lazy.load("vtk")
 
 __all__ = [
     "BASE",
@@ -295,10 +297,10 @@ def cast_UnstructuredGrid_to_PolyData(  # noqa: N802
         raise TypeError(emsg)
 
     # see https://vtk.org/pipermail/vtkusers/2011-March/066506.html
-    alg = _vtk.vtkGeometryFilter()
+    alg = pv._vtk.vtkGeometryFilter()
     alg.AddInputData(mesh)
     alg.Update()
-    result = _get_output(alg)
+    result = pv.core.filters._get_output(alg)
 
     if clean:
         result = result.clean()
@@ -579,7 +581,7 @@ def nan_mask(data: ArrayLike) -> np.ndarray:
     """
     if np.ma.isMaskedArray(data):
         if data.dtype.char not in np.typecodes["Float"]:
-            data = ma.asanyarray(data, dtype=float)
+            data = np.ma.asanyarray(data, dtype=float)
 
         data = data.filled(np.nan)
 
@@ -914,9 +916,9 @@ def vtk_warnings_off() -> None:
     .. versionadded:: 0.1.0
 
     """
-    vtkObject.GlobalWarningDisplayOff()
+    vtk.vtkObject.GlobalWarningDisplayOff()
     # https://gitlab.kitware.com/vtk/vtk/-/issues/18785
-    vtkLogger.SetStderrVerbosity(vtkLogger.VERBOSITY_OFF)
+    vtk.vtkLogger.SetStderrVerbosity(vtk.vtkLogger.VERBOSITY_OFF)
 
 
 def vtk_warnings_on() -> None:
@@ -927,9 +929,9 @@ def vtk_warnings_on() -> None:
     .. versionadded:: 0.1.0
 
     """
-    vtkObject.GlobalWarningDisplayOn()
+    vtk.vtkObject.GlobalWarningDisplayOn()
     # https://gitlab.kitware.com/vtk/vtk/-/issues/18785
-    vtkLogger.SetStderrVerbosity(vtkLogger.VERBOSITY_INFO)
+    vtk.vtkLogger.SetStderrVerbosity(vtk.vtkLogger.VERBOSITY_INFO)
 
 
 def wrap(

--- a/src/geovista/core.py
+++ b/src/geovista/core.py
@@ -17,8 +17,7 @@ from enum import Enum, auto, unique
 from typing import TYPE_CHECKING
 import warnings
 
-import numpy as np
-import pyvista as pv
+import lazy_loader as lazy
 
 from .common import (
     CENTRAL_MERIDIAN,
@@ -47,6 +46,11 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from numpy.typing import ArrayLike
+    import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pv = lazy.load("pyvista")
 
 __all__ = [
     "MeridianSlice",

--- a/src/geovista/crs.py
+++ b/src/geovista/crs.py
@@ -14,13 +14,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
+import lazy_loader as lazy
 from pyproj import CRS
 
 from .common import GV_FIELD_CRS
 
 if TYPE_CHECKING:
     import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
 
 __all__ = [
     "CRSLike",

--- a/src/geovista/geodesic.py
+++ b/src/geovista/geodesic.py
@@ -17,9 +17,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 import warnings
 
-import numpy as np
-import pyproj
-import pyvista as pv
+import lazy_loader as lazy
 
 from .common import (
     GV_FIELD_RADIUS,
@@ -34,7 +32,14 @@ from .common import cast_UnstructuredGrid_to_PolyData as cast
 from .crs import WGS84, to_wkt
 
 if TYPE_CHECKING:
+    import numpy as np
     from numpy.typing import ArrayLike
+    import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pyproj = lazy.load("pyproj")
+pv = lazy.load("pyvista")
 
 __all__ = [
     "BBox",

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -15,12 +15,11 @@ Notes
 from __future__ import annotations
 
 from functools import lru_cache
+import os
 from typing import TYPE_CHECKING, Any
 from warnings import warn
 
-from pyproj import CRS
-import pyvista as pv
-from pyvista.core.utilities import helpers
+import lazy_loader as lazy
 
 from .bridge import Transform
 from .common import (
@@ -34,6 +33,7 @@ from .common import (
     distance,
     point_cloud,
     to_cartesian,
+    vtk_warnings_off,
 )
 from .common import cast_UnstructuredGrid_to_PolyData as cast
 from .core import add_texture_coords, resize, slice_mesh
@@ -64,7 +64,12 @@ from .raster import wrap_texture
 from .transform import transform_mesh
 
 if TYPE_CHECKING:
-    import numpy.typing as npt
+    from numpy.typing import ArrayLike
+    import pyvista as pv
+
+# lazy import third-party dependencies
+pyproj = lazy.load("pyproj")
+pv = lazy.load("pyvista")
 
 __all__ = ["GeoPlotter"]
 
@@ -171,7 +176,7 @@ class GeoPlotterBase:
 
         if "crs" in kwargs:
             crs = kwargs.pop("crs")
-            crs = CRS.from_user_input(crs) if crs is not None else WGS84
+            crs = pyproj.CRS.from_user_input(crs) if crs is not None else WGS84
         else:
             crs = WGS84
         self.crs = crs
@@ -561,6 +566,10 @@ class GeoPlotterBase:
         .. versionadded:: 0.1.0
 
         """
+        # assume this is a sane default
+        if os.environ.get("GEOVISTA_VTK_WARNINGS", "false").lower() == "false":
+            vtk_warnings_off()
+
         if isinstance(mesh, pv.UnstructuredGrid):
             mesh = cast(mesh)
 
@@ -988,14 +997,14 @@ class GeoPlotterBase:
 
     def add_points(
         self,
-        points: npt.ArrayLike | pv.PolyData | None = None,
-        xs: npt.ArrayLike | None = None,
-        ys: npt.ArrayLike | None = None,
-        scalars: str | npt.ArrayLike | None = None,
+        points: ArrayLike | pv.PolyData | None = None,
+        xs: ArrayLike | None = None,
+        ys: ArrayLike | None = None,
+        scalars: str | ArrayLike | None = None,
         crs: CRSLike | None = None,
         radius: float | None = None,
         style: str | None = None,
-        zlevel: int | npt.ArrayLike | None = None,
+        zlevel: int | ArrayLike | None = None,
         zscale: float | None = None,
         **kwargs: Any | None,
     ) -> pv.Actor:
@@ -1054,7 +1063,7 @@ class GeoPlotterBase:
         """
         if crs is not None:
             # sanity check the source crs
-            crs = CRS.from_user_input(crs)
+            crs = pyproj.CRS.from_user_input(crs)
 
         if style is None:
             style = "points"
@@ -1089,8 +1098,8 @@ class GeoPlotterBase:
                 )
                 raise ValueError(emsg)
 
-            if not helpers.is_pyvista_dataset(points):
-                points = helpers.wrap(points)
+            if not pv.core.utilities.helpers.is_pyvista_dataset(points):
+                points = pv.core.utilities.helpers.wrap(points)
 
             mesh = points
 

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -16,8 +16,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import numpy as np
-import pyvista as pv
+import lazy_loader as lazy
 
 from .common import (
     BASE,
@@ -32,6 +31,11 @@ from .crs import WGS84, to_wkt
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
+    import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pv = lazy.load("pyvista")
 
 __all__ = [
     "GRATICULE_CLOSED_INTERVAL",

--- a/src/geovista/pantry/__init__.py
+++ b/src/geovista/pantry/__init__.py
@@ -12,11 +12,19 @@ Notes
 """
 from __future__ import annotations
 
-import pooch
-import pyvista as pv
+from typing import TYPE_CHECKING
+
+import lazy_loader as lazy
 
 from geovista.cache import CACHE
 from geovista.common import COASTLINES_RESOLUTION
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+# lazy import third-party dependencies
+pooch = lazy.load("pooch")
+pv = lazy.load("pyvista")
 
 __all__ = [
     "fetch_coastlines",

--- a/src/geovista/pantry/data.py
+++ b/src/geovista/pantry/data.py
@@ -17,16 +17,19 @@ from enum import Enum
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
-import netCDF4 as nc  # noqa: N813
-import numpy as np
-from numpy import ma
-import pooch
+import lazy_loader as lazy
 
 from geovista.cache import CACHE
 from geovista.common import LRU_CACHE_SIZE, _MixinStrEnum
 
 if TYPE_CHECKING:
+    import netCDF4 as nc  # noqa: N813
     from numpy.typing import ArrayLike
+
+# lazy import third-party dependencies
+nc = lazy.load("netCDF4")
+np = lazy.load("numpy")
+pooch = lazy.load("pooch")
 
 __all__ = [
     "CLOUD_AMOUNT_PREFERENCE",
@@ -330,7 +333,7 @@ def fesom(step: int | None = None) -> SampleUnstructuredXY:
     assert np.array_equal(lons_mask, lats_mask), emsg
 
     mask = np.hstack([np.zeros(n_cells, dtype=bool).reshape(-1, 1), lons_mask])
-    connectivity = ma.arange(np.prod(shape), dtype=np.uint32).reshape(shape)
+    connectivity = np.ma.arange(np.prod(shape), dtype=np.uint32).reshape(shape)
     connectivity.mask = mask
 
     return SampleUnstructuredXY(

--- a/src/geovista/pantry/meshes.py
+++ b/src/geovista/pantry/meshes.py
@@ -12,16 +12,23 @@ Notes
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from warnings import warn
 
-import numpy as np
-import pooch
-import pyvista as pv
+import lazy_loader as lazy
 
 from geovista.bridge import Transform
 from geovista.cache import CACHE
 from geovista.common import Preference
 import geovista.pantry
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pooch = lazy.load("pooch")
+pv = lazy.load("pyvista")
 
 __all__ = [
     "LFRIC_RESOLUTION",

--- a/src/geovista/pantry/textures.py
+++ b/src/geovista/pantry/textures.py
@@ -13,9 +13,20 @@ Notes
 
 from __future__ import annotations
 
-import pyvista as pv
+from typing import TYPE_CHECKING
+
+import lazy_loader as lazy
 
 from geovista.cache import CACHE
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+    # type aliases
+    TextureLike = str | pv.Texture
+
+# lazy import third-party dependencies
+pv = lazy.load("pyvista")
 
 __all__ = [
     "blue_marble",
@@ -23,10 +34,6 @@ __all__ = [
     "natural_earth_1",
     "natural_earth_hypsometric",
 ]
-
-
-# Type aliases.
-TextureLike = str | pv.Texture
 
 
 def _fetch_texture(fname: str, location: bool | None = False) -> TextureLike:

--- a/src/geovista/raster.py
+++ b/src/geovista/raster.py
@@ -12,10 +12,18 @@ Notes
 """
 from __future__ import annotations
 
-import numpy as np
-import pyvista as pv
+from typing import TYPE_CHECKING
+
+import lazy_loader as lazy
 
 from .common import wrap
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pv = lazy.load("pyvista")
 
 __all__ = ["wrap_texture"]
 

--- a/src/geovista/report.py
+++ b/src/geovista/report.py
@@ -14,8 +14,11 @@ from __future__ import annotations
 
 from types import ModuleType
 
-import pyvista
+import lazy_loader as lazy
 import scooby
+
+# lazy import third-party dependencies
+pv = lazy.load("pyvista")
 
 __all__ = ["Report"]
 
@@ -121,7 +124,7 @@ class Report(scooby.Report):
         # attempt to detect gpu hardware details
         if gpu:
             try:
-                extra_meta = pyvista.GPUInfo().get_info()
+                extra_meta = pv.GPUInfo().get_info()
             except:  # noqa: E722
                 # bare except required in order to handle rendering faults
                 extra_meta = [

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-import numpy as np
-from pyproj import CRS, Transformer
+import lazy_loader as lazy
 
 from .common import GV_FIELD_ZSCALE, ZLEVEL_SCALE, from_cartesian, point_cloud
 from .crs import (
@@ -32,6 +31,9 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
     import pyvista as pv
 
+# lazy import third-party dependencies
+np = lazy.load("numpy")
+pyproj = lazy.load("pyproj")
 
 __all__ = [
     "transform_mesh",
@@ -99,7 +101,7 @@ def transform_mesh(
         raise ValueError(emsg)
 
     # sanity check the target crs
-    tgt_crs = CRS.from_user_input(tgt_crs)
+    tgt_crs = pyproj.CRS.from_user_input(tgt_crs)
 
     original_tgt_crs = deepcopy(tgt_crs)
     transform_required = src_crs != tgt_crs
@@ -289,8 +291,8 @@ def transform_points(
         zs = np.atleast_1d(zs)
 
     # sanity check the crs's
-    src_crs = CRS.from_user_input(src_crs)
-    tgt_crs = CRS.from_user_input(tgt_crs)
+    src_crs = pyproj.CRS.from_user_input(src_crs)
+    tgt_crs = pyproj.CRS.from_user_input(tgt_crs)
 
     # sanity check spatial arrays
     if (xndim := xs.ndim) > 2 or (yndim := ys.ndim) > 2:
@@ -360,7 +362,7 @@ def transform_points(
     if src_crs == tgt_crs:
         result = combine(xs, ys, zs)
     else:
-        transformer = Transformer.from_crs(src_crs, tgt_crs, always_xy=True)
+        transformer = pyproj.Transformer.from_crs(src_crs, tgt_crs, always_xy=True)
         transformed = transformer.transform(xs, ys, zs, errcheck=trap)
 
         if zs is None:

--- a/tests/transform/test_transform_points.py
+++ b/tests/transform/test_transform_points.py
@@ -7,11 +7,12 @@
 from __future__ import annotations
 
 import numpy as np
+from pyproj import Transformer
 from pyproj.exceptions import CRSError
 import pytest
 
 from geovista.crs import WGS84
-from geovista.transform import Transformer, transform_points
+from geovista.transform import transform_points
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request addresses the slow `import geovista` time, which can take between `~2.5 - 3secs`.

Incorporating these changes reduces this overhead to `>100msecs` e.g.,

```
> python -X importtime -c "import geovista"

import time: self [us] | cumulative | imported package
import time:       358 |        358 |   _io
import time:        45 |         45 |   marshal
import time:      1122 |       1122 |   posix
import time:       447 |       1971 | _frozen_importlib_external
import time:       142 |        142 |   time
import time:       143 |        285 | zipimport
import time:       343 |        343 |     _codecs
import time:       301 |        644 |   codecs
import time:      2160 |       2160 |   encodings.aliases
import time:      3720 |       6522 | encodings
import time:      1399 |       1399 | encodings.utf_8
import time:       157 |        157 | _signal
import time:        39 |         39 |     _abc
import time:       129 |        167 |   abc
import time:       185 |        351 | io
import time:        55 |         55 |       _stat
import time:        76 |        130 |     stat
import time:       983 |        983 |     _collections_abc
import time:        43 |         43 |       genericpath
import time:        77 |        120 |     posixpath
import time:       394 |       1625 |   os
import time:        75 |         75 |   _sitebuiltins
import time:      2670 |       2670 |   encodings.ascii
import time:      6912 |       6912 |   _distutils_hack
import time:      2233 |       2233 |   types
import time:      2212 |       2212 |       warnings
import time:      2422 |       4633 |     importlib
import time:      2316 |       2316 |     importlib._abc
import time:       448 |       7396 |   importlib.util
import time:       162 |        162 |   importlib.machinery
import time:      1843 |       1843 |   sitecustomize
import time:       296 |        296 |   usercustomize
import time:      8697 |      31905 | site
import time:      1591 |       1591 |   __future__
import time:       375 |        375 |             _operator
import time:      1864 |       2238 |           operator
import time:       495 |        495 |               itertools
import time:      1072 |       1072 |               keyword
import time:       941 |        941 |               reprlib
import time:       400 |        400 |               _collections
import time:      5082 |       7988 |             collections
import time:       135 |        135 |             _functools
import time:      2501 |      10624 |           functools
import time:      3972 |      16833 |         enum
import time:       201 |        201 |           _sre
import time:      2777 |       2777 |             re._constants
import time:      2517 |       5294 |           re._parser
import time:      1931 |       1931 |           re._casefix
import time:      2924 |      10348 |         re._compiler
import time:      1470 |       1470 |         copyreg
import time:      4198 |      32847 |       re
import time:      1530 |       1530 |       _ast
import time:      2050 |       2050 |       contextlib
import time:      6311 |      42737 |     ast
import time:       827 |        827 |           _opcode
import time:      1356 |       2182 |         opcode
import time:      2321 |       4503 |       dis
import time:      1688 |       1688 |       collections.abc
import time:      2540 |       2540 |           token
import time:        55 |         55 |           _tokenize
import time:      3857 |       6451 |         tokenize
import time:      1324 |       7774 |       linecache
import time:      7455 |      21418 |     inspect
import time:      2806 |      66960 |   lazy_loader
import time:     12285 |      12285 |   geovista._version
import time:      5287 |      86122 | geovista

```

Granted, this is just delaying or spreading the inevitable cost of importing the larger third-party packages e.g., `pyvista`, `vtk`, `numpy`, `pyproj`, but from a user perspective this is perhaps attractive.

Closes #647

---
