### PR TITLE
tidy geovista module namespace

### DIFF
--- a/src/geovista/__init__.py
+++ b/src/geovista/__init__.py
@@ -7,13 +7,13 @@
 
 Provides:
   1. An agnostic bridge to transform rectilinear, curvilinear and unstructured
-     geospatial data to native geolocated PyVista mesh instances
+     geospatial data to native geolocated PyVista mesh instances.
   2. Compliments PyVista with cartographic features for processing, projecting
-     and rendering geolocated meshes
-  3. Support for interactive 3D visualization of geolocated meshes
+     and rendering geolocated meshes.
+  3. Support for interactive 3D visualization of geolocated meshes.
   4. Coordinate Reference System (CRS) support, with an awareness of Cartopy
      CRSs through the commonality of the Python interface to PROJ (PyPROJ)
-     package
+     package.
 
 Notes
 -----

--- a/src/geovista/__init__.pyi
+++ b/src/geovista/__init__.pyi
@@ -1,6 +1,5 @@
 # see https://scientific-python.org/specs/spec-0001/#type-checkers
 from .bridge import Transform
-from .geodesic import BBox, line, panel, wedge
 from .geoplotter import GeoPlotter
 from .pantry.textures import (
     blue_marble,
@@ -11,15 +10,11 @@ from .pantry.textures import (
 from .report import Report
 
 __all__ = [
-    "BBox",
     "GeoPlotter",
     "Report",
     "Transform",
     "blue_marble",
     "checkerboard",
-    "line",
     "natural_earth_1",
     "natural_earth_hypsometric",
-    "panel",
-    "wedge",
 ]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request tidies the `geovista` module namespace, purging the `geovista.geodesic` behaviour.

The original contents was speculative at best, and #669 reminded me that the top level imports required some TLC.

On reflection, we'll be extending the geometric primitives supported by `geovista`, so placing geodesic geometries in the `geovista` namespace will ultimately be confusing i.e., we'll have support for non-geodesic lines, bounding boxes etc so it's better for the user to import these explicitly e.g., we've already experienced a user initially completely bamboozled by the `geovista.BBox` as they didn't expect it to be a manifold bound by great circles 🤯 

---
