### PR TITLE
autodoc typehints in doc-string description only

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -50,6 +50,7 @@ def autolog(message: str) -> None:
 extensions = [
     #    "jupyter_sphinx",
     "autoapi.extension",
+    "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
@@ -131,6 +132,11 @@ napoleon_use_param = True
 napoleon_use_rtype = True
 napoleon_use_keyword = True
 napoleon_custom_sections = None
+
+
+# -- autoapi options ---------------------------------------------------------
+# See https://sphinx-autoapi.readthedocs.io/en/latest/how_to.html#how-to-include-type-annotations-as-types-in-rendered-docstrings
+autodoc_typehints = "description"
 
 
 # -- autoapi options ---------------------------------------------------------
@@ -271,6 +277,7 @@ intersphinx_mapping = {
     "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
+    "pyproj": ("https://pyproj4.github.io/pyproj/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "pyvista": ("https://docs.pyvista.org/", None),
 }

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -391,7 +391,7 @@ class Transform:
             :data:`NAME_POINTS` or :data:`NAME_CELLS`.
         crs : CRSLike, optional
             The Coordinate Reference System of the provided `xs` and `ys`. May
-            be anything accepted by :meth:`pyproj.CRS.from_user_input`. Defaults
+            be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`. Defaults
             to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float, optional
             The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
@@ -475,7 +475,7 @@ class Transform:
             :data:`NAME_POINTS` or :data:`NAME_CELLS`.
         crs : CRSLike, optional
             The Coordinate Reference System of the provided `xs` and `ys`. May
-            be anything accepted by :meth:`pyproj.CRS.from_user_input`. Defaults
+            be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`. Defaults
             to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float, optional
             The radius of the sphere. Defaults to :data:`geovista.common.RADIUS`.
@@ -566,7 +566,7 @@ class Transform:
             is provided but with no `name`, defaults to :data:`NAME_POINTS`.
         crs : CRSLike, optional
             The Coordinate Reference System of the provided `xs` and `ys`. May
-            be anything accepted by :meth:`pyproj.CRS.from_user_input`. Defaults
+            be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`. Defaults
             to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float, optional
             The radius of the mesh point-cloud. Defaults to
@@ -703,7 +703,7 @@ class Transform:
             :data:`NAME_POINTS` or :data:`NAME_CELLS`.
         crs : CRSLike, optional
             The Coordinate Reference System of the provided `xs` and `ys`. May
-            be anything accepted by :meth:`pyproj.CRS.from_user_input`. Defaults
+            be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`. Defaults
             to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float, optional
             The radius of the mesh sphere. Defaults to :data:`geovista.common.RADIUS`.
@@ -922,7 +922,7 @@ class Transform:
             from the `connectivity`.
         crs : CRSLike, optional
             The Coordinate Reference System of the provided `xs` and `ys`. May
-            be anything accepted by :meth:`pyproj.CRS.from_user_input`. Defaults
+            be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`. Defaults
             to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float, optional
             The radius of the mesh sphere. Defaults to :data:`geovista.common.RADIUS`.

--- a/src/geovista/crs.py
+++ b/src/geovista/crs.py
@@ -51,7 +51,7 @@ WGS84 = CRS.from_user_input("epsg:4326")
 
 
 def from_wkt(mesh: pv.PolyData) -> CRS:
-    """Get the :class:`pyproj.CRS` associated with the mesh.
+    """Get the :class:`pyproj.crs.CRS` associated with the mesh.
 
     Parameters
     ----------
@@ -61,7 +61,7 @@ def from_wkt(mesh: pv.PolyData) -> CRS:
     Returns
     -------
     CRS
-        The :class:`pyproj.CRS`
+        The :class:`pyproj.crs.CRS`
 
     Notes
     -----
@@ -85,7 +85,7 @@ def get_central_meridian(crs: CRS) -> float | None:
     Parameters
     ----------
     crs : CRS
-        The :class:`pyproj.CRS`.
+        The :class:`pyproj.crs.CRS`.
 
     Returns
     -------
@@ -177,7 +177,7 @@ def set_central_meridian(crs: CRS, meridian: float) -> CRS | None:
     Parameters
     ----------
     crs : CRS
-        The :class:`pyproj.CRS`.
+        The :class:`pyproj.crs.CRS`.
     meridian : float
         The replacement central meridian.
 
@@ -210,16 +210,16 @@ def set_central_meridian(crs: CRS, meridian: float) -> CRS | None:
 
 
 def to_wkt(mesh: pv.PolyData, crs: CRS) -> None:
-    """Attach serialized :class:`pyproj.CRS` as Well-Known-Text in-place to the `mesh`.
+    """Attach serialized :class:`pyproj.crs.CRS` as Well-Known-Text to the `mesh`.
 
-    The serialized OGC WKT is attached to the ``field_data`` of the mesh.
+    The serialized OGC WKT is attached to the ``field_data`` of the mesh in-place.
 
     Parameters
     ----------
     mesh : PolyData
         The mesh to contain the OGC WKT.
     crs : CRS
-        The :class:`pyproj.CRS` to be serialized.
+        The :class:`pyproj.crs.CRS` to be serialized.
 
     Notes
     -----

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -1031,7 +1031,7 @@ class GeoPlotterBase:
             scalars on the `points` mesh are used.
         crs : CRSLike, optional
             The Coordinate Reference System of the provided `points`, or `xs` and `ys`.
-            May be anything accepted by :meth:`pyproj.CRS.from_user_input`. Defaults
+            May be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`. Defaults
             to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float, optional
             The radius of the mesh point-cloud. Defaults to

--- a/src/geovista/transform.py
+++ b/src/geovista/transform.py
@@ -193,11 +193,11 @@ def transform_point(
     src_crs : CRSLike
         The source Coordinate Reference System (CRS) of the provided `x`,
         `y` and `z` spatial point. May be anything accepted by
-        :meth:`pyproj.CRS.from_user_input`.
+        :meth:`pyproj.crs.CRS.from_user_input`.
     tgt_crs : CRSLike
         The target Coordinate Reference System (CRS) of the transform for
         the spatial point. May be anything accepted by
-        :meth:`pyproj.CRS.from_user_input`.
+        :meth:`pyproj.crs.CRS.from_user_input`.
     x : ArrayLike
         The spatial point x-value, in canonical `src_crs` units, to be
         transformed from the `src_crs` to the `tgt_crs`. May be scalar
@@ -249,11 +249,11 @@ def transform_points(
     src_crs : CRSLike
         The source Coordinate Reference System (CRS) of the provided `xs`,
         `ys` and `zs` spatial points. May be anything accepted by
-        :meth:`pyproj.CRS.from_user_input`.
+        :meth:`pyproj.crs.CRS.from_user_input`.
     tgt_crs : CRSLike
         The target Coordinate Reference System (CRS) of the transform for
         the spatial points. May be anything accepted by
-        :meth:`pyproj.CRS.from_user_input`.
+        :meth:`pyproj.crs.CRS.from_user_input`.
     xs : ArrayLike
         The spatial points x-values, in canonical `src_crs` units, to be
         transformed from the `src_crs` to the `tgt_crs`. May be scalar,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request ensures that typehints are only rendered in the documented docstring `description` and not the `signature`.

This makes for cleaner rendered documentation.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/bjlittle/geovista/assets/2051656/056403a7-8a86-4ce1-bea5-31a7ee05e7f2) | ![image](https://github.com/bjlittle/geovista/assets/2051656/f438960a-b9d2-435d-8b2f-e6f7fb7fd115) |

Additionally, `pyproj` is added to intersphinx and references to the `CRS.from_user_input` method is corrected. 

---
