### PR TITLE
fix lock2yaml for py310

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -35,6 +35,11 @@ lint.ignore = [
     "ANN001",  # Missing type annotation for function argument.
     "ANN201",  # Missing return type annotation for public function.
 ]
+"requirements/locks/lock2yaml.py" = [
+    # flake8-use-pathlib (PTH)
+    # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "PTH123",  # open() should be replaced by Path.open()
+]
 "src/geovista/geoplotter.py" = [
     # flake8-annotations (ANN)
     # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann

--- a/requirements/locks/lock2yaml.py
+++ b/requirements/locks/lock2yaml.py
@@ -7,7 +7,6 @@
 """Convert a lock file to a YAML file."""
 from __future__ import annotations
 
-from pathlib import Path
 import sys
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -27,8 +26,9 @@ lock = f"{env}-linux-64.txt"
 name = f"geovista-{env}"
 yaml = f"{env}-linux-64.yml"
 
-with Path.open(lock) as fin:
+# TODO @bjlittle: use Path.open when >=py311 and remove .ruff.toml ignore
+with open(lock) as fin:
     content = template.render(file=fin, name=name)
 
-with Path.open(yaml, mode="w", encoding="utf-8") as fout:
+with open(yaml, mode="w", encoding="utf-8") as fout:
     fout.write(content)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds the `ruff` ignore rule `PTH123` for the `lock2yaml` script.

This rule exception may be removed once the minimum supported version is `python>=3.11` i.e., `pathlib.Path.open` isn't supported in `py310`.

---
