### PR TITLE
cli docs tidy and options rebrand

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -150,6 +150,8 @@ autoapi_dirs = [
 ]
 autoapi_root = "reference/generated/api"
 autoapi_ignore = [
+    str(package_dir / "geovista/__main__.py"),
+    str(package_dir / "geovista/cli.py"),
     str(package_dir / "geovista/examples/*"),
 ]
 autoapi_member_order = "alphabetical"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request opts not to document the `geovista.cli` as there is no expectation for the user to `import geovista.cli`.

However, the `geovista.cli.main` implements the entry point to the command line interface (CLI) using `click`, which is self-documenting from the CLI e.g., `geovista --help`.

The `download` command option `-o|--output` is rebranded to `-t|--target`, and the `examples` command ensures that the name of an example is provided.

---
