### PR TITLE
fix lock2yaml eof newline

### DIFF
--- a/requirements/locks/lock2yaml.py
+++ b/requirements/locks/lock2yaml.py
@@ -32,3 +32,4 @@ with open(lock) as fin:
 
 with open(yaml, mode="w", encoding="utf-8") as fout:
     fout.write(content)
+    fout.write("\n")


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Require to add a newline at the end of the yaml file, otherwise the `fix end of files` `pre-commit` hook fails.

---
