### PR TITLE
demote rasterio as optional dependency

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -20,7 +20,6 @@ dependencies:
   - pykdtree
   - pyproj >=3.3
   - pyvista >=0.43.1
-  - rasterio >=1.3
 
 # pantry dependencies (core)
   - netcdf4
@@ -46,6 +45,7 @@ dependencies:
   - h3-py
   - pandas
   - pyarrow
+  - rasterio >=1.3
 
 # documentation dependencies (optional)
   - jupyter_sphinx

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -10,4 +10,3 @@ pooch
 pykdtree
 pyproj>=3.3
 pyvista>=0.43.1
-rasterio>=1.3

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -2,3 +2,4 @@ fastparquet
 h3
 pandas
 pyarrow
+rasterio>=1.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request demotes `rasterio` as an optional dependency, as it is a large dependency that may not be required by default.

---
