### PR TITLE
add geotiff support

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -176,12 +176,14 @@ tags_badge_colors = {
     "Curvilinear": "secondary",
     "Extrude": "dark",
     "Globe": "success",
+    "GeoTIFF": "secondary",
     "Graticule": "primary",
     "Lighting": "primary",
     "Opacity": "primary",
     "Points": "secondary",
     "Point Cloud": "secondary",
     "Projection": "success",
+    "RGB": "primary",
     "Rectilinear": "secondary",
     "Texture": "primary",
     "Threshold": "primary",
@@ -192,11 +194,11 @@ tags_badge_colors = {
 }
 tags_create_tags = True
 tags_create_badges = True
-tags_index_head = "Gallery examples categorised by tag:"  # tags landing page intro text
+tags_index_head = "Examples categorised by tag:"  # tags landing page intro text
 tags_intro_text = "🏷 Tags:"  # prefix text for a tags list
 tags_overview_title = "🏷 Tags"  # title for the tags landing page
 tags_output_dir = "tags"
-tags_page_header = "Gallery examples:"  # tag sub-page, header text
+tags_page_header = "Examples:"  # tag sub-page, header text
 tags_page_title = "🏷 Tag"  # tag sub-page, title appended with the tag name
 
 
@@ -408,7 +410,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pyvista": ("https://docs.pyvista.org/version/stable/", None),
     "pyvistaqt": ("https://qtdocs.pyvista.org/", None),
-    "rasterio": ("https://rasterio.readthedocs.io/en/latest/", None),
+    "rasterio": ("https://rasterio.readthedocs.io/en/stable/", None),
 }
 
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -236,6 +236,7 @@ numpydoc_xref_aliases = {
     "CloudPreference": "geovista.pantry.data.CloudPreference",
     "Corners": "geovista.geodesic.Corners",
     "Geod": "pyproj.geod.Geod",
+    "Path": "pathlib.Path",
     "Preference": "geovista.common.Preference",
     "PolyData": "pyvista.PolyData",
     "Shape": "geovista.bridge.Shape",
@@ -407,6 +408,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pyvista": ("https://docs.pyvista.org/version/stable/", None),
     "pyvistaqt": ("https://qtdocs.pyvista.org/", None),
+    "rasterio": ("https://rasterio.readthedocs.io/en/latest/", None),
 }
 
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -194,11 +194,11 @@ tags_badge_colors = {
 }
 tags_create_tags = True
 tags_create_badges = True
-tags_index_head = "Examples categorised by tag:"  # tags landing page intro text
+tags_index_head = "Gallery examples categorised by tag:"  # tags landing page intro text
 tags_intro_text = "🏷 Tags:"  # prefix text for a tags list
 tags_overview_title = "🏷 Tags"  # title for the tags landing page
 tags_output_dir = "tags"
-tags_page_header = "Examples:"  # tag sub-page, header text
+tags_page_header = "Gallery examples:"  # tag sub-page, header text
 tags_page_title = "🏷 Tag"  # tag sub-page, title appended with the tag name
 
 

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -783,21 +783,19 @@ class Transform:  # numpydoc ignore=PR01
                     else:
                         name = name.format(units=units)
 
-            if extract:
-                data = src.read(masked=True) if rgb else src.read(band, masked=True)
+            data = src.read(masked=extract) if rgb else src.read(band, masked=extract)
 
+            if extract:
                 # ignore the mask on the alpha channel, if present
                 mask = data[0].mask & data[1].mask & data[2].mask if rgb else data.mask
                 # ensure there is masked data prior to extracting unmasked points
                 extract = np.sum(mask) > 0
-
                 data = data.data
-                if rgb:
-                    data = np.dstack(data).reshape(-1, count)
-            else:
-                data = src.read(band)
 
-            height, width = data.shape
+            if rgb:
+                data = np.dstack(data).reshape(-1, count)
+
+            height, width = src.height, src.width
             cols, rows = np.meshgrid(np.arange(width), np.arange(height))
             xs, ys = rio.transform.xy(src.transform, rows, cols)
             mesh = cls.from_2d(
@@ -810,6 +808,7 @@ class Transform:  # numpydoc ignore=PR01
                 zlevel=zlevel,
                 zscale=zscale,
                 clean=clean,
+                rgb=rgb,
             )
 
             if extract:

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -44,9 +44,9 @@ if TYPE_CHECKING:
 
 # lazy import third-party dependencies
 np = lazy.load("numpy")
-rio = lazy.load("rasterio")
 pv = lazy.load("pyvista")
 pyproj = lazy.load("pyproj")
+rio = lazy.load("rasterio")
 
 __all__ = [
     "BRIDGE_CLEAN",
@@ -835,11 +835,13 @@ class Transform:  # numpydoc ignore=PR01
                 if sieve:
                     from rasterio.features import sieve as riosieve
 
-                    # convert boolean mask to conform to GDAL RFC 15
+                    # convert boolean mask to conform to GDAL RFC 15 for sieve
                     # see https://trac.osgeo.org/gdal/wiki/rfc15_nodatabitmask
-                    mask = (~mask * 255).astype(src.dtypes[0])
+                    dtype = np.dtype(src.dtypes[0])
+                    muint = 2 ** (dtype.itemsize * 8) - 1
+                    mask = (~mask * muint).astype(dtype)
                     mask = riosieve(mask, size=size)
-                    # convert mask back to boolean
+                    # convert back to boolean mask
                     mask = ~mask.astype(bool)
 
                 # extract cells with no masked points

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -770,8 +770,6 @@ class Transform:  # numpydoc ignore=PR01
         dynamic range in the ``uint8`` image data. Then, extract the mesh to remove
         cells with no masked points.
 
-        .. tags:: GeoTIFF, Lighting, RGB
-
         >>> from geovista import Transform
         >>> from geovista.pantry import fetch_raster
         >>> fname = fetch_raster("bahamas_rgb.tif")

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -757,6 +757,27 @@ class Transform:  # numpydoc ignore=PR01
         PolyData
             The GeoTIFF spherical mesh.
 
+        Notes
+        -----
+        .. versionadded:: 0.5.0
+
+        Examples
+        --------
+        Render the GeoTIFF ``RGB`` image as a geolocated mesh.
+
+        First, :func:`rasterio.features.sieve` the GeoTIFF image to remove several
+        unwanted masked regions within the interior of the image, due to a lack of
+        dynamic range in the ``uint8`` image data. Then, extract the mesh to remove
+        cells with no masked points.
+
+        .. tags:: GeoTIFF, Lighting, RGB
+
+        >>> from geovista import Transform
+        >>> from geovista.pantry import fetch_raster
+        >>> fname = fetch_raster("bahamas_rgb.tif")
+        >>> mesh = Transform.from_tiff(fname, rgb=True, sieve=True, extract=True)
+        >>> mesh.plot(cpos="xz", lighting=False, rgb=True)
+
         """
         try:
             import rasterio as rio

--- a/src/geovista/examples/scalar_data/earthquakes.py
+++ b/src/geovista/examples/scalar_data/earthquakes.py
@@ -68,7 +68,7 @@ def main() -> None:
         sample = usgs_earthquakes()
     except ImportError:
         wmsg = (
-            "Missing optional dependencies 'pandas' and 'fastparquet' are "
+            "Optional dependencies 'pandas' and 'fastparquet' are "
             "required for the 'earthquakes' example. Use pip or conda to "
             "install them."
         )

--- a/src/geovista/examples/scalar_data/earthquakes.py
+++ b/src/geovista/examples/scalar_data/earthquakes.py
@@ -70,7 +70,7 @@ def main() -> None:
         wmsg = (
             "Optional dependencies 'pandas' and 'fastparquet' are "
             "required for the 'earthquakes' example. Use pip or conda to "
-            "install them."
+            "install these packages."
         )
         warn(wmsg, stacklevel=2)
         return

--- a/src/geovista/examples/scalar_data/earthquakes_wink1.py
+++ b/src/geovista/examples/scalar_data/earthquakes_wink1.py
@@ -71,7 +71,7 @@ def main() -> None:
         wmsg = (
             "Optional dependencies 'pandas' and 'fastparquet' are "
             "required for the 'earthquakes' example. Use pip or conda to "
-            "install them."
+            "install these packages."
         )
         warn(wmsg, stacklevel=2)
         return

--- a/src/geovista/examples/scalar_data/earthquakes_wink1.py
+++ b/src/geovista/examples/scalar_data/earthquakes_wink1.py
@@ -69,7 +69,7 @@ def main() -> None:
         sample = usgs_earthquakes()
     except ImportError:
         wmsg = (
-            "Missing optional dependencies 'pandas' and 'fastparquet' are "
+            "Optional dependencies 'pandas' and 'fastparquet' are "
             "required for the 'earthquakes' example. Use pip or conda to "
             "install them."
         )

--- a/tests/bridge/test_from_tiff.py
+++ b/tests/bridge/test_from_tiff.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.Transform.from_tiff`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from geovista.bridge import Transform
+from geovista.pantry import fetch_raster
+
+# convert to string to exercise conversion back to Path
+fname: str = str(fetch_raster("bahamas_rgb.tif"))
+
+
+@pytest.mark.parametrize(
+    ("count", "emsg"),
+    [
+        (1, "Require a band index of 1"),
+        (3, r"Require a band index in the closed interval \[1, 3\]"),
+    ],
+)
+@pytest.mark.parametrize("band", [0, 4])
+def test_band_fail(mocker, band, count, emsg):
+    """Test out of range image band."""
+    dataset = mocker.MagicMock(count=count)
+    mocker.patch("rasterio.open").return_value.__enter__.return_value = dataset
+
+    with pytest.raises(ValueError, match=emsg):
+        _ = Transform.from_tiff(fname, band=band)
+
+
+def test_rgb_band_fail(mocker):
+    """Test rgb/rgba image bands."""
+    dataset = mocker.MagicMock(count=2)
+    mocker.patch("rasterio.open").return_value.__enter__.return_value = dataset
+
+    emsg = "Require a GeoTIFF with 3 or 4 bands"
+    with pytest.raises(ValueError, match=emsg):
+        _ = Transform.from_tiff(fname, rgb=True)
+
+
+@pytest.mark.parametrize("rgb", [True])
+@pytest.mark.parametrize("band", [1, 2, 3])
+@pytest.mark.parametrize("unit", ["m", None])
+def test_rgb_band(mocker, rgb, band, unit):
+    """Test band behaviour with name units substitution."""
+    if rgb:
+        band = 3
+    crs = mocker.sentinel.crs
+    data = mocker.sentinel.data
+    mocked_read = mocker.MagicMock(return_value=data)
+    transform = mocker.sentinel.transform
+    height, width = 2, 3
+    kwargs = {
+        "count": band,
+        "crs": crs,
+        "height": height,
+        "read": mocked_read,
+        "transform": transform,
+        "units": [unit] * band,
+        "width": width,
+    }
+    dataset = mocker.MagicMock(**kwargs)
+    mocker.patch("rasterio.open").return_value.__enter__.return_value = dataset
+
+    if rgb:
+        mocked_reshape = mocker.MagicMock(return_value=data)
+        mocked_dstack = mocker.patch(
+            "numpy.dstack", return_value=mocker.MagicMock(reshape=mocked_reshape)
+        )
+
+    cols, rows = mocker.sentinel.cols, mocker.sentinel.rows
+    mocked_meshgrid = mocker.patch("numpy.meshgrid", return_value=(cols, rows))
+
+    xs, ys = mocker.sentinel.xs, mocker.sentinel.ys
+    mocked_xy = mocker.patch("rasterio.transform.xy", return_value=(xs, ys))
+
+    expected = mocker.sentinel.mesh
+    mocked_from_2d = mocker.patch(
+        "geovista.bridge.Transform.from_2d", return_value=expected
+    )
+
+    name = "Elevation [{units}]"
+    actual = Transform.from_tiff(fname, name=name, band=band, rgb=rgb)
+
+    assert actual == expected
+
+    args = () if rgb else (band,)
+    mocked_read.assert_called_once_with(*args, masked=False)
+
+    if rgb:
+        mocked_dstack.assert_called_once_with(data)
+        mocked_reshape.assert_called_once_with(-1, band)
+
+    mocked_meshgrid.assert_called_once()
+    args = mocked_meshgrid.call_args.args
+    assert len(args) == 2
+    np.testing.assert_array_equal(args[0], np.arange(width))
+    np.testing.assert_array_equal(args[1], np.arange(height))
+
+    mocked_xy.assert_called_once_with(transform, rows, cols)
+
+    kwargs = {"radius": None, "zlevel": None, "zscale": None, "clean": None}
+    mocked_from_2d.assert_called_once_with(
+        xs,
+        ys,
+        data=data,
+        name=name.format(units=str(unit)),
+        crs=crs,
+        rgb=rgb,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("sieve", [True])
+@pytest.mark.parametrize("rgb", [False, True])
+@pytest.mark.parametrize("masked", [False, True])
+def test_extract(mocker, masked, rgb, sieve):
+    """Test extract behaviour with and without image masking."""
+    height, width = 2, 3
+    band = 3 if rgb else 1
+    crs = mocker.sentinel.crs
+    dtypes = ["uint8"] * band
+    size = mocker.sentinel.size
+    transform = mocker.sentinel.transform
+
+    shape = (band, height, width)
+    data = np.ma.arange(np.prod(shape)).reshape(shape)
+    mask = np.zeros(shape, dtype=bool)
+    if masked:
+        mask[:, 1:, :] = True
+    if not rgb:
+        data, mask = data[0], mask[0]
+    data.mask = mask
+    mocked_read = mocker.MagicMock(return_value=data)
+
+    kwargs = {
+        "count": band,
+        "crs": crs,
+        "dtypes": dtypes,
+        "height": height,
+        "read": mocked_read,
+        "transform": transform,
+        "width": width,
+    }
+    dataset = mocker.MagicMock(**kwargs)
+    mocker.patch("rasterio.open").return_value.__enter__.return_value = dataset
+
+    cols, rows = mocker.sentinel.cols, mocker.sentinel.rows
+    mocked_meshgrid = mocker.patch("numpy.meshgrid", return_value=(cols, rows))
+
+    xs, ys = mocker.sentinel.xs, mocker.sentinel.ys
+    mocked_xy = mocker.patch("rasterio.transform.xy", return_value=(xs, ys))
+
+    expected_mesh = mocker.sentinel.mesh
+    mesh = expected_mesh
+    mocked_extract = mocker.MagicMock(return_value=expected_mesh)
+    if masked:
+        mesh = mocker.MagicMock(extract_points=mocked_extract)
+    mocked_from_2d = mocker.patch(
+        "geovista.bridge.Transform.from_2d", return_value=mesh
+    )
+
+    mocked_sieve = mocker.patch(
+        "rasterio.features.sieve",
+        side_effect=lambda mask, size: mask,  # noqa: ARG005
+    )
+
+    mocked_cast = mocker.patch(
+        "geovista.bridge.cast_UnstructuredGrid_to_PolyData", return_value=expected_mesh
+    )
+
+    actual = Transform.from_tiff(
+        fname, band=band, rgb=rgb, sieve=sieve, size=size, extract=True
+    )
+
+    assert actual == expected_mesh
+
+    mocked_meshgrid.assert_called_once()
+    args = mocked_meshgrid.call_args.args
+    assert len(args) == 2
+    np.testing.assert_array_equal(args[0], np.arange(width))
+    np.testing.assert_array_equal(args[1], np.arange(height))
+
+    mocked_xy.assert_called_once_with(transform, rows, cols)
+
+    if rgb:
+        data = np.dstack(data).reshape(-1, band)
+        mask = mask[0]
+
+    mocked_from_2d.assert_called_once()
+    assert mocked_from_2d.call_args.args == (xs, ys)
+    expected_kwargs = {
+        "name": None,
+        "crs": crs,
+        "rgb": rgb,
+        "radius": None,
+        "zlevel": None,
+        "zscale": None,
+        "clean": None,
+    }
+    kwargs = mocked_from_2d.call_args.kwargs
+    actual = kwargs.pop("data")
+    assert kwargs == expected_kwargs
+    np.testing.assert_array_equal(actual, data.data)
+
+    if masked:
+        if sieve:
+            gdal_mask = (~mask).astype(dtypes[0]) * 255
+            assert mocked_sieve.call_count == 1
+            args = mocked_sieve.call_args.args
+            assert len(args) == 1
+            np.testing.assert_array_equal(args[0], gdal_mask)
+            assert mocked_sieve.call_args.kwargs == {"size": size}
+
+        assert mocked_extract.call_count == 1
+        args = mocked_extract.call_args.args
+        assert len(args) == 1
+        np.testing.assert_array_equal(args[0], ~np.ravel(mask))
+        assert mocked_extract.call_args.kwargs == {"adjacent_cells": False}
+
+        mocked_cast.assert_called_once_with(expected_mesh)
+    else:
+        assert mocked_sieve.call_count == 0
+        assert mocked_extract.call_count == 0
+        assert mocked_cast.call_count == 0


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request extends the `geovista.Transform` API to include GeoTIFF support via the `from_tiff` method.

This will allow RGB/RGBA image meshes to be rendered, and also easily allow Digital Elevation Model (DEM) data to be ingested (warped) and rendered. 

Example geolocated RGB mesh created from a GeoTIFF:
![image](https://github.com/bjlittle/geovista/assets/2051656/054b163a-0e4e-4cb3-9dd7-7266c70bf806)


TODO:

- [x] Add test coverage

---
