### PR TITLE
revert README examples to 0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ colormap.
 
 ```python
 import geovista as gv
-from geovista.pantry.data import ww3_global_tri
+from geovista.pantry import ww3_global_tri
 import geovista.theme
 
 # Load the sample data.
@@ -188,7 +188,7 @@ from an [FVCOM](http://fvcom.smast.umassd.edu/fvcom/) **unstructured** mesh, as 
 
 ```python
 import geovista as gv
-from geovista.pantry.data import fvcom_tamar
+from geovista.pantry import fvcom_tamar
 import geovista.theme
 
 # Load the sample data.
@@ -239,7 +239,7 @@ base layer.
 
 ```python
 import geovista as gv
-from geovista.pantry.data import lam_pacific
+from geovista.pantry import lam_pacific
 import geovista.theme
 
 # Load the sample data.
@@ -283,7 +283,7 @@ base layer.
 import cartopy.crs as ccrs
 
 import geovista as gv
-from geovista.pantry.data import lam_pacific
+from geovista.pantry import lam_pacific
 import geovista.theme
 
 # Load the sample data.
@@ -325,7 +325,7 @@ Now render a [Met Office LFRic](https://www.metoffice.gov.uk/research/approach/m
 
 ```python
 import geovista as gv
-from geovista.pantry.data import lfric_sst
+from geovista.pantry import lfric_sst
 import geovista.theme
 
 # Load the sample data.
@@ -364,7 +364,7 @@ using Met Office Unified Model (UM) ORCA2 Sea Water Potential Temperature data, 
 
 ```python
 import geovista as gv
-from geovista.pantry.data import um_orca2
+from geovista.pantry import um_orca2
 import geovista.theme
 
 # Load sample data.
@@ -402,7 +402,7 @@ Now let's render a [NOAA/NCEI Optimum Interpolation SST](https://www.ncei.noaa.g
 
 ```python
 import geovista as gv
-from geovista.pantry.data import oisst_avhrr_sst
+from geovista.pantry import oisst_avhrr_sst
 import geovista.theme
 
 # Load sample data.
@@ -442,7 +442,7 @@ model uses hexagonal and pentagonal cells, and is a new dynamical core for
 
 ```python
 import geovista as gv
-from geovista.pantry.data import dynamico
+from geovista.pantry import dynamico
 import geovista.theme
 
 # Load sample data.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request reverts the `README.md` examples to align with `0.4.x`, as most users will be installing `geovista` from `conda-forge` or `PyPI`.

Prior to `0.5.0`, these changes require to be reverted back to align with the breaking change of the `geovista.pantry` module reorganisation.

Closes #782 

---
