### PR TITLE
drop toml install from setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Defined by PEP 518
 requires = [
     "setuptools>=64",
-    "setuptools_scm[toml]>=8",
+    "setuptools_scm>=8",
 ]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This is no longer necessary.

Performing `pip install setuptools_scm[toml]` is equivalent to `pip install setuptools_scm` from version `>=8`

---
