### PR TITLE
remove test examples cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ image_cache_dir = "tests/plotting/image_cache"
 log_cli = "True"
 log_cli_level = "INFO"
 markers = [
-    "example: geovista example image tests",
-    "image: plotter rendering image tests",
+    "example: gallery image tests",
+    "image: plotting image tests",
 ]
 minversion = "6.0"
 required_plugins = "pytest-mock pytest_pyvista"

--- a/tests/plotting/test_examples.py
+++ b/tests/plotting/test_examples.py
@@ -11,7 +11,6 @@ import importlib
 
 import pytest
 
-from geovista.cache import CACHE
 from geovista.common import get_modules
 
 from . import CI
@@ -43,9 +42,5 @@ def test(example, verify_image_cache):
     verify_image_cache.test_name = f"test_{safe}"
     # import the example module
     module = importlib.import_module(f"geovista.examples.{example}")
-    # if necessary, download and cache missing example base image (expected) to
-    # compare with the actual test image generated via pytest-pyvista plugin
-    if verify_image_cache.add_missing_images is False:
-        _ = CACHE.fetch(f"tests/images/{safe}.png")
     # execute the example module for image testing
     module.main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request backs-out the gallery examples per test image caching, which requires an alternative approach to align with the generic image testing introduced by #819.

---
