### PR TITLE
rebrand um to nemo for orca2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <a href="https://github.com/bjlittle/geovista#--------">
-    <img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/branding/logo/primary/geovistalogo.svg"
+    <img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/branding/logo/primary/geovistalogo.svg"
          alt="GeoVista"
          width="200"></a>
 </h1>
@@ -185,7 +185,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/ww3-tri.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/ww3-tri.png" style="width: 75%; height: 75%"></p>
 
 #### Finite Volume Community Ocean Model
 
@@ -228,7 +228,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/tamar.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/tamar.png" style="width: 75%; height: 75%"></p>
 
 #### CF UGRID
 
@@ -277,7 +277,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/lam-moll.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/lam-moll.png" style="width: 75%; height: 75%"></p>
 
 Using the same **unstructured** LAM data, reproject to
 [Equidistant Cylindrical](https://proj.org/operations/projections/eqc.html) but this time using a
@@ -321,7 +321,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/lam-eqc.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/lam-eqc.png" style="width: 75%; height: 75%"></p>
 
 #### LFRic Cube-Sphere
 
@@ -361,12 +361,12 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/lfric-robin.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/lfric-robin.png" style="width: 75%; height: 75%"></p>
 
-#### UM ORCA2
+#### NEMO ORCA2
 
 So far we've demonstrated GeoVista's ability to cope with **unstructured** data. Now let's plot a **curvilinear** mesh
-using Met Office Unified Model (UM) ORCA2 Sea Water Potential Temperature data, with
+using Nucleus for European Modelling of the Ocean (NEMO) ORCA2 Sea Water Potential Temperature data, with
 [10m Natural Earth coastlines](https://www.naturalearthdata.com/downloads/10m-physical-vectors/10m-coastline/) and a
 [1:50m Natural Earth I](https://www.naturalearthdata.com/downloads/50m-raster-data/50m-natural-earth-1/) base layer.
 
@@ -375,11 +375,11 @@ using Met Office Unified Model (UM) ORCA2 Sea Water Potential Temperature data, 
 
 ```python
 import geovista as gv
-from geovista.pantry import um_orca2
+from geovista.pantry import nemo_orca2
 import geovista.theme
 
 # Load sample data.
-sample = um_orca2()
+sample = nemo_orca2()
 
 # Create the mesh from the sample data.
 mesh = gv.Transform.from_2d(sample.lons, sample.lats, data=sample.data)
@@ -399,7 +399,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/um-orca.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/nemo-orca.png" style="width: 75%; height: 75%"></p>
 
 #### OISST AVHRR
 
@@ -437,7 +437,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/oisst-avhrr.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/oisst-avhrr.png" style="width: 75%; height: 75%"></p>
 
 #### DYNAMICO
 
@@ -472,7 +472,7 @@ plotter.show()
 ```
 </details>
 
-<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2023.09.1/media/readme/dynamico-icosahedral.png" style="width: 75%; height: 75%"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/bjlittle/geovista-media/2024.06.0/media/readme/dynamico-icosahedral.png" style="width: 75%; height: 75%"></p>
 
 ## Further Examples
 

--- a/src/geovista/examples/curvilinear/from_2d__orca.py
+++ b/src/geovista/examples/curvilinear/from_2d__orca.py
@@ -32,7 +32,7 @@ Natural Earth base layer is rendered along with Natural Earth coastlines.
 from __future__ import annotations
 
 import geovista as gv
-from geovista.pantry.data import um_orca2
+from geovista.pantry.data import nemo_orca2
 import geovista.theme
 
 
@@ -45,7 +45,7 @@ def main() -> None:
 
     """
     # Load the sample data.
-    sample = um_orca2()
+    sample = nemo_orca2()
 
     # Create the mesh from the sample data.
     mesh = gv.Transform.from_2d(sample.lons, sample.lats, data=sample.data)

--- a/src/geovista/examples/curvilinear/from_2d__orca_moll.py
+++ b/src/geovista/examples/curvilinear/from_2d__orca_moll.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import geovista as gv
 from geovista.common import cast_UnstructuredGrid_to_PolyData as cast
-from geovista.pantry.data import um_orca2
+from geovista.pantry.data import nemo_orca2
 import geovista.theme
 from geovista.transform import transform_mesh
 
@@ -49,7 +49,7 @@ def main() -> None:
 
     """
     # Load the sample data.
-    sample = um_orca2()
+    sample = nemo_orca2()
 
     # Create the mesh from the sample data.
     mesh = gv.Transform.from_2d(sample.lons, sample.lats, data=sample.data)

--- a/src/geovista/examples/point_cloud/from_points__orca_cloud.py
+++ b/src/geovista/examples/point_cloud/from_points__orca_cloud.py
@@ -33,7 +33,7 @@ Earth base layer with opacity.
 from __future__ import annotations
 
 import geovista as gv
-from geovista.pantry.data import um_orca2_gradient
+from geovista.pantry.data import nemo_orca2_gradient
 from geovista.pantry.meshes import ZLEVEL_SCALE_CLOUD
 import geovista.theme
 
@@ -47,7 +47,7 @@ def main() -> None:
 
     """
     # Load the sample data.
-    sample = um_orca2_gradient()
+    sample = nemo_orca2_gradient()
 
     # Create the point cloud from the sample data.
     cloud = gv.Transform.from_points(

--- a/src/geovista/examples/point_cloud/from_points__orca_cloud_eqc.py
+++ b/src/geovista/examples/point_cloud/from_points__orca_cloud_eqc.py
@@ -35,7 +35,7 @@ projection.
 from __future__ import annotations
 
 import geovista as gv
-from geovista.pantry.data import um_orca2_gradient
+from geovista.pantry.data import nemo_orca2_gradient
 from geovista.pantry.meshes import ZLEVEL_SCALE_CLOUD
 import geovista.theme
 
@@ -49,7 +49,7 @@ def main() -> None:
 
     """
     # Load the sample data.
-    sample = um_orca2_gradient()
+    sample = nemo_orca2_gradient()
 
     # Create the point cloud from the sample data.
     cloud = gv.Transform.from_points(

--- a/src/geovista/pantry/data.py
+++ b/src/geovista/pantry/data.py
@@ -53,9 +53,10 @@ __all__ = [
     "lam_uk",
     "lfric_orog",
     "lfric_sst",
+    "lfric_sst",
+    "nemo_orca2",
+    "nemo_orca2_gradient",
     "oisst_avhrr_sst",
-    "um_orca2",
-    "um_orca2_gradient",
     "usgs_earthquakes",
     "ww3_global_smc",
     "ww3_global_tri",
@@ -755,10 +756,10 @@ def oisst_avhrr_sst() -> SampleStructuredXY:
 
 
 @lru_cache(maxsize=LRU_CACHE_SIZE)
-def um_orca2() -> SampleStructuredXY:
+def nemo_orca2() -> SampleStructuredXY:
     """Download and cache structured surface sample data.
 
-    Load Met Office Unified Model (UM) ORCA2 curvilinear mesh.
+    Load NEMO ORCA2 curvilinear mesh.
 
     Returns
     -------
@@ -788,10 +789,10 @@ def um_orca2() -> SampleStructuredXY:
 
 
 @lru_cache(maxsize=LRU_CACHE_SIZE)
-def um_orca2_gradient() -> SampleStructuredXYZ:
+def nemo_orca2_gradient() -> SampleStructuredXYZ:
     """Download and cache cloud-point sample data.
 
-    Load Met Office Unified Model (UM) ORCA2 curvilinear mesh with gradient filter.
+    Load NEMO ORCA2 curvilinear mesh with gradient filter.
 
     Returns
     -------

--- a/src/geovista/pantry/meshes.py
+++ b/src/geovista/pantry/meshes.py
@@ -53,10 +53,10 @@ __all__ = [
     "lfric",
     "lfric_orog",
     "lfric_sst",
+    "nemo_orca2",
+    "nemo_orca2_cloud",
     "oisst_avhrr_sst",
     "regular_grid",
-    "um_orca2",
-    "um_orca2_cloud",
     "ww3_global_smc",
     "ww3_global_tri",
 ]
@@ -555,6 +555,63 @@ def lfric_sst() -> pv.PolyData:
     )
 
 
+def nemo_orca2() -> pv.PolyData:
+    """Create a mesh from :mod:`geovista.pantry.data` sample data.
+
+    Generate a global Sea Water Potential Temperature ORCA2 mesh.
+
+    Returns
+    -------
+    PolyData
+        The ORCA2 mesh.
+
+    Notes
+    -----
+    .. versionadded:: 0.1.0
+
+    """
+    sample = geovista.pantry.data.nemo_orca2()
+
+    return Transform.from_2d(
+        sample.lons, sample.lats, data=sample.data, name=sample.name
+    )
+
+
+def nemo_orca2_cloud(zscale: float | None = None) -> pv.PolyData:
+    """Create a point-cloud mesh from :mod:`geovista.pantry.data` sample data.
+
+    Generate an ORCA2 point-cloud of Sea Water Potential Temperature gradients.
+
+    Parameters
+    ----------
+    zscale : float, optional
+        The proportional multiplier for z-axis ``zlevel``. Defaults to
+        :data:`ZLEVEL_SCALE_CLOUD`.
+
+    Returns
+    -------
+    PolyData
+        The ORCA2 point-cloud.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.0
+
+    """
+    sample = geovista.pantry.data.nemo_orca2_gradient()
+
+    zscale = ZLEVEL_SCALE_CLOUD if zscale is None else float(zscale)
+
+    return Transform.from_points(
+        sample.lons,
+        sample.lats,
+        data=sample.zlevel,
+        name=sample.name,
+        zlevel=-sample.zlevel,
+        zscale=zscale,
+    )
+
+
 def oisst_avhrr_sst() -> pv.PolyData:
     """Create a mesh from :mod:`geovista.pantry.data` sample data.
 
@@ -632,63 +689,6 @@ def regular_grid(
     lons = np.linspace(-180.0, 180.0, int(n_cells * 1.5) + 1)
 
     return Transform.from_1d(lons, lats, radius=radius)
-
-
-def um_orca2() -> pv.PolyData:
-    """Create a mesh from :mod:`geovista.pantry.data` sample data.
-
-    Generate a global Sea Water Potential Temperature ORCA2 mesh.
-
-    Returns
-    -------
-    PolyData
-        The ORCA2 mesh.
-
-    Notes
-    -----
-    .. versionadded:: 0.1.0
-
-    """
-    sample = geovista.pantry.data.um_orca2()
-
-    return Transform.from_2d(
-        sample.lons, sample.lats, data=sample.data, name=sample.name
-    )
-
-
-def um_orca2_cloud(zscale: float | None = None) -> pv.PolyData:
-    """Create a point-cloud mesh from :mod:`geovista.pantry.data` sample data.
-
-    Generate an ORCA2 point-cloud of Sea Water Potential Temperature gradients.
-
-    Parameters
-    ----------
-    zscale : float, optional
-        The proportional multiplier for z-axis ``zlevel``. Defaults to
-        :data:`ZLEVEL_SCALE_CLOUD`.
-
-    Returns
-    -------
-    PolyData
-        The ORCA2 point-cloud.
-
-    Notes
-    -----
-    .. versionadded:: 0.2.0
-
-    """
-    sample = geovista.pantry.data.um_orca2_gradient()
-
-    zscale = ZLEVEL_SCALE_CLOUD if zscale is None else float(zscale)
-
-    return Transform.from_points(
-        sample.lons,
-        sample.lats,
-        data=sample.zlevel,
-        name=sample.name,
-        zlevel=-sample.zlevel,
-        zscale=zscale,
-    )
 
 
 def ww3_global_smc(step: int | None = None) -> pv.PolyData:

--- a/tests/pantry/meshes/test__points_cells.py
+++ b/tests/pantry/meshes/test__points_cells.py
@@ -172,16 +172,16 @@ def test_oisst_avhrr_sst():
     assert mesh.n_cells == 1036800
 
 
-def test_um_orca2():
-    """Test generation of um orca2 mesh."""
-    mesh = meshes.um_orca2()
+def test_nemo_orca2():
+    """Test generation of nemo orca2 mesh."""
+    mesh = meshes.nemo_orca2()
     assert mesh.n_points == 106560
     assert mesh.n_cells == 26640
 
 
-def test_um_orca2_cloud():
-    """Test generation of um orca2 cloud mesh."""
-    mesh = meshes.um_orca2_cloud()
+def test_nemo_orca2_cloud():
+    """Test generation of nemo orca2 cloud mesh."""
+    mesh = meshes.nemo_orca2_cloud()
     assert mesh.n_points == 265791
     assert mesh.n_cells == 265791
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request correctly attributes the ORCA2 curvilinear grid to NEMO rather then the Met Office UM.

- `geovista.pantry.data.um_orca2` -> `geovista.pantry.data.nemo_orca2`
- `geovista.pantry.data.um_orca2_gradient` -> `geovista.pantry.data.nemo_orca2_gradient`
- `geovista.pantry.meshes.um_orca2` -> `geovista.pantry.meshes.nemo_orca2`
- `geovista.pantry.meshes.um_orca2_cloud` -> `geovista.pantry.meshes.nemo_orca2_cloud`

---
