### PR TITLE
nep29 numpy>=1.24 min pin

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -14,7 +14,7 @@ dependencies:
   - click
   - click-default-group
   - lazy_loader
-  - numpy >=1.23
+  - numpy >=1.24
   - platformdirs
   - pooch
   - pykdtree
@@ -51,7 +51,7 @@ dependencies:
   - numpydoc
   - pydata-sphinx-theme >=0.15.3
   - sphinx >=7.3
-  - sphinx-autoapi
+  - sphinx-autoapi >=3.1
   - sphinx-book-theme >=1.1.3
   - sphinx-copybutton
   - sphinx-design

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -1,12 +1,12 @@
-cartopy>=0.22
+cartopy >=0.22
 click
 click-default-group
 cmocean
 lazy_loader
 netCDF4
-numpy>=1.23
+numpy >=1.24
 platformdirs
 pooch
 pykdtree
-pyproj>=3.3
-pyvista>=0.43.1
+pyproj >=3.3
+pyvista >=0.43.1

--- a/requirements/pypi-optional-docs.txt
+++ b/requirements/pypi-optional-docs.txt
@@ -1,7 +1,7 @@
 numpydoc
 sphinx >=7.3
 sphinx_design
-sphinx-autoapi
+sphinx-autoapi >=3.1
 sphinx-book-theme >=1.1.3
 sphinx-copybutton
 sphinx-gallery >=0.16

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -2,4 +2,4 @@ fastparquet
 h3
 pandas
 pyarrow
-rasterio>=1.3
+rasterio >=1.3

--- a/requirements/pypi-optional-test.txt
+++ b/requirements/pypi-optional-test.txt
@@ -1,6 +1,6 @@
 codecov
 pre-commit
-pytest>=6.0
+pytest >=6.0
 pytest-cov
 pytest-mock
 pytest-pyvista


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces the [NEP-29 droptable](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) for `numpy`, and also introduces a minimum pin for `sphinx-autoapi`.

---
