### PR TITLE
docs: toggle open margin notes

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,7 +6,7 @@ GeoVista Documentation
 ======================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/next_steps.rst
+++ b/docs/src/next_steps.rst
@@ -6,9 +6,10 @@
 =========================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
+
 
 After a brief :ref:`overview <gv-overview>` and
 :ref:`introduction <gv-quick-start>` to ``geovista``, hopefully you'll be keen

--- a/docs/src/quick_start.rst
+++ b/docs/src/quick_start.rst
@@ -56,7 +56,7 @@ Examples
    pyvista.global_theme.anti_aliasing = 'fxaa'
 
 .. note::
-  :class: margin
+  :class: margin, dropdown, toggle-shown
 
   The **Interactive Scene**
   `vtk.js <https://kitware.github.io/vtk-js/index.html>`_ backend does **not**

--- a/docs/src/reference/about.rst
+++ b/docs/src/reference/about.rst
@@ -4,9 +4,10 @@
 ==========================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
+
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in consectetur orci. Nam convallis viverra dolor in.
 

--- a/docs/src/reference/bindings.rst
+++ b/docs/src/reference/bindings.rst
@@ -4,7 +4,7 @@
 ==============================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/reference/changelog.rst
+++ b/docs/src/reference/changelog.rst
@@ -4,7 +4,7 @@
 =======================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/reference/cli.rst
+++ b/docs/src/reference/cli.rst
@@ -4,7 +4,7 @@
 =====================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/reference/environment.rst
+++ b/docs/src/reference/environment.rst
@@ -4,7 +4,7 @@
 ======================================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/reference/glossary.rst
+++ b/docs/src/reference/glossary.rst
@@ -4,7 +4,7 @@
 =============================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -4,7 +4,7 @@
 ========================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/docs/src/reference/whatsnew.rst
+++ b/docs/src/reference/whatsnew.rst
@@ -4,7 +4,7 @@
 =======================================
 
 .. note::
-    :class: margin
+    :class: margin, dropdown, toggle-shown
 
     Content marked with 🚧 indicates it's still under construction.
 

--- a/src/geovista/examples/README.rst
+++ b/src/geovista/examples/README.rst
@@ -4,22 +4,25 @@
 :fa:`images` Examples
 *********************
 
+.. note::
+  :class: margin, dropdown, toggle-shown
+
+  The **Interactive Scene**
+  `vtk.js <https://kitware.github.io/vtk-js/index.html>`_ backend does **not** support
+  rendering text or points as spheres.
+
+
 This interactive gallery highlights the growing capabilities and
 features of ``geovista``.
 
 It is generated from the ``geovista.examples``, which can also
 be run from the command line with:
 
-.. note::
-  :class: margin
-
-  The **Interactive Scene**
-  `vtk.js <https://kitware.github.io/vtk-js/index.html>`_ backend does **not** support
-  rendering text or points as spheres.
 
 .. code:: console
 
     geovista examples --all --verbose
+
 
 .. note::
     :class: dropdown


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request makes the margin `notes` open toggles. 

The ability to close an open toggle margin note is most useful when browsing the documentation on a limited real-estate mobile platform.

---
