### PR TITLE
docs: use os.walk not pathlib.Path.walk

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -623,7 +623,9 @@ def generate_carousel(
     :margin: {margin}
 """
 
-    for root, _, files in base.walk():
+    # TODO @bjlittle: use Path.walk when python >=3.12
+    for root, _, files in os.walk(str(base)):
+        root = Path(root)  # noqa: PLW2901
         if root.name == "images":
             root_relative = root.relative_to(app.srcdir)
             link_relative = root.parent.relative_to(app.srcdir)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull request reverts to using `os.walk` instead of `pathlib.Path.walk`, which was only introduced in Python 3.12.

Discovered this issue whilst serendipitously building the docs gallery carousel using `python==3.11`.

The GHA CI is configured to only build the docs with the latest supported version of `python`, which is 3.12.

---
