### PR TITLE
reformat all-contributors table

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -8,8 +8,9 @@
   ],
   "commit": true,
   "commitConvention": "none",
-  "contributorsPerLine": 7,
+  "contributorsPerLine": 6,
   "contributorsSortAlphabetically": true,
+  "imageSize": 75,
   "linkToUsage": true,
   "contributors": [
     {


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The `all-contributors` table doesn't render very well on a reduced footprint mobile platform, so attempting to compromise by reducing the number of entries per row and the image size.

<details>
<summary>Click to expand mobile screenshot </summary>

![Screenshot (2 Jul 2024 14 41 21)](https://github.com/bjlittle/geovista/assets/2051656/73653c42-5eb7-4e8a-83d3-78375a29dd28)

</details>

---
