### PR TITLE
patch: fix gridline tests for np 2.x

### DIFF
--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -345,7 +345,7 @@ def create_meridians(
             mesh.point_data[GV_REMESH_POINT_IDS] = seam
             mesh.set_active_scalars(name=None)
 
-        blocks[f"{index},{lon!r}"] = mesh
+        blocks[f"{index},{lon}"] = mesh
 
     grid_points, grid_labels = [], []
     labels = create_meridian_labels(list(lons))
@@ -539,7 +539,7 @@ def create_parallels(
 
         mesh = pv.PolyData(xyz, lines=lines)
         to_wkt(mesh, WGS84)
-        blocks[f"{index},{lat!r}"] = mesh
+        blocks[f"{index},{lat}"] = mesh
         grid_lats.append(lat)
 
     grid_points, grid_labels = [], []


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Now that `pyvista` 0.44 is released with `numpy` 2.x support :partying_face:, it made it easy to investigate and propose the simple fix to address the failing `geovista.gridlines` tests.

Essentially, `numpy` 2.x was injecting the scalar type for the `__repr__` used in the multi-blocks keys. We can safely remove this to make `geovista` work with both `numpy` 1.x and 2.x.

Closes #849

N.B., there appears to be some optional `geovista` dependencies holding back `conda` resolving the environment with `numpy` 2.x ... but that will untangle itself in the fullness of time, and isn't a blocker.

---
