### PR TITLE
tests: skip optional rasterio tests

### DIFF
--- a/tests/bridge/test_from_tiff.py
+++ b/tests/bridge/test_from_tiff.py
@@ -13,6 +13,9 @@ import pytest
 from geovista.bridge import Transform
 from geovista.pantry import fetch_raster
 
+# skip tests if rasterio package unavailable
+pytest.importorskip("rasterio")
+
 # convert to string to exercise conversion back to Path
 fname: str = str(fetch_raster("bahamas_rgb.tif"))
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This PR skips the `tests.bridge.test_from_tiff` if the `rasterio` package is not installed.

---
