### PR TITLE
docs: move tags

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -251,11 +251,11 @@ tags_badge_colors = {
 
 tags_create_tags = True
 tags_create_badges = True
-tags_index_head = "Gallery examples organised by tag:"  # tags landing page intro text
+tags_index_head = "Themed content tags:"  # tags landing page intro text
 tags_intro_text = "Tags:"  # prefix text for a tags list
 tags_overview_title = ":fa:`tags` Tags"  # title for the tags landing page
 tags_output_dir = "tags"
-tags_page_header = "Gallery examples:"  # tag sub-page, header text
+tags_page_header = "Tagged content:"  # tag sub-page, header text
 tags_page_title = ":fa:`tags` Tag"  # tag sub-page, title appended with the tag name
 
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -119,7 +119,6 @@ We'd 💛 to hear from you.
     :hidden:
 
     generated/gallery/index
-    tags/tagsindex
 
 
 .. toctree::

--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -80,6 +80,17 @@ Consult our reference material for no fuss facts about ``geovista``.
 
         Jargon buster.
 
+    .. grid-item-card:: Tags
+        :class-title: custom-title
+        :class-body: custom-body
+        :link: tagoverview
+        :link-type: ref
+        :img-top: ../_static/images/icons/tags.svg
+        :class-img-top: dark-light
+        :class-card: sd-rounded-3
+
+        Themed content tags.
+
 .. comment
 
     # TBD @bjlittle: add these cards back
@@ -105,7 +116,6 @@ Consult our reference material for no fuss facts about ``geovista``.
         :class-card: sd-rounded-3
 
         Release highlights.
-
 
 
 .. toctree::


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request removes the `tags` link from the primary sidebar and moves it to the `Reference` landing page.

Essentially, whenever a gallery example is rendered the `tags` automatically expands in the sidebar, which is noisy and confusing for the user.

Note that, the `tags` has not been added to the sidebar under the `Reference` section, it is only accessed via a card on the `Reference` landing page.

---
