### PR TITLE
docs: min pin sphinx-autoapi >=3.0.0

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -337,7 +337,6 @@ autodoc_typehints_description_target = "documented"
 #     https://github.com/readthedocs/sphinx-autoapi
 #
 
-autoapi_type = "python"
 autoapi_dirs = [
     package_src_dir,
 ]

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -53,7 +53,7 @@ dependencies:
   - numpydoc
   - pydata-sphinx-theme >=0.15.3
   - sphinx >=7.3
-  - sphinx-autoapi
+  - sphinx-autoapi >=3.0.0
   - sphinx-book-theme >=1.1.3
   - sphinx-click
   - sphinx-copybutton

--- a/requirements/pypi-optional-docs.txt
+++ b/requirements/pypi-optional-docs.txt
@@ -3,7 +3,7 @@ myst-nb
 numpydoc
 sphinx >=7.3
 sphinx_design
-sphinx-autoapi
+sphinx-autoapi >=3.0.0
 sphinx-book-theme >=1.1.3
 sphinx-click
 sphinx-copybutton


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request purges the use of the `sphinx-autoapi` configuration `autoapi_type`, which was removed after version 2.1.1.

As a result, the next available version 3.0.0 is introduced as a minimum package pin.

---
