### PR TITLE
docs: fix page footer author

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -160,6 +160,10 @@ project = "GeoVista"
 now = datetime.datetime.now(datetime.UTC)
 copyright_years = f"2021 - {now.year}"
 copyright = f"{copyright_years}, {project} Contributors"  # noqa: A001
+# Explicitly unset to save rendering by sphinx as an additional line on the
+# page footer, thus minimising the footer footprint. Instead, append "author"
+# to "copyright".
+author = ""
 
 on_rtd = os.environ.get("READTHEDOCS") == "True"
 rtd_version = os.environ.get("READTHEDOCS_VERSION")


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

There has been a change in the docs theme that is now rendering the unset `author` variable from the `config.py` in the page footer:

![image](https://github.com/user-attachments/assets/00129f78-8cb8-4061-ab7b-8708700325b5)

The changes of this pull-request to resolve this and maintain the status quo:

![image](https://github.com/user-attachments/assets/6c3d7255-4457-4441-9253-ee8499739b1a)



---
