### PR TITLE
docs: rename gallery-carousel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/src/gallery-carousel.txt
+docs/src/gallery_carousel.txt
 docs/src/generated
 docs/src/reference/generated
 docs/src/tags

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,7 +25,7 @@ clean:
 	-rm -rf $(SOURCEDIR)/reference/generated
 	-rm -rf $(SOURCEDIR)/tags
 	-rm -f $(SOURCEDIR)/sg_execution_times.rst
-	-rm -f $(SOURCEDIR)/gallery-carousel.txt
+	-rm -f $(SOURCEDIR)/gallery_carousel.txt
 
 doctest:
 	@$(SPHINXBUILD) -b doctest -D plot_gallery=False -D plot_docstring=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/doctest"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -773,7 +773,7 @@ def geovista_carousel(
 ) -> None:
     """Create the gallery carousel."""
     # create empty or truncate existing file
-    fname = Path(app.srcdir, "gallery-carousel.txt")
+    fname = Path(app.srcdir, "gallery_carousel.txt")
 
     with fname.open("w"):
         pass

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -88,7 +88,7 @@ We'd 💛 to hear from you.
     knowledge discovery (`Diátaxis`_)
 
 
-.. include:: gallery-carousel.txt
+.. include:: gallery_carousel.txt
 
 
 .. toctree::


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request renames the auto-generated `gallery-carousel.rst` file to be `gallery_carousel.rst` instead, so as to adopt the same implicit documentation file naming convention.

---
