### PR TITLE
docs: add towncrier changelog support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 prune .github
 prune .tox
+prune changelog
 prune docs
 prune requirements
 recursive-include requirements *.txt
@@ -14,6 +15,7 @@ exclude .pre-commit-config.yaml
 exclude .readthedocs.yml
 exclude .ruff.toml
 include *.md
+exclude CHANGELOG.rst
 include CITATION.cff
 exclude codecov.yml
 exclude tox.ini

--- a/changelog/.gitignore
+++ b/changelog/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/changelog/1025.documentation.rst
+++ b/changelog/1025.documentation.rst
@@ -1,0 +1,2 @@
+Added initial `towncrier <https://github.com/twisted/towncrier>`__ infrastructure
+to support the ``changelog``. (:user:`bjlittle`)

--- a/changelog/template.rst
+++ b/changelog/template.rst
@@ -1,0 +1,40 @@
+{% for section in sections %}
+{% set underline = underlines[0] %}
+{% if section %}
+{{ section }}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+{% if sections[section] %}
+{% for category in definitions if category in sections[section] %}
+
+{{ definitions[category]['name'] }}
+{{ underline * (definitions[category]['name']|length + 1) }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category]|dictsort(by='value') %}
+{% if not values or values[0][0] == '+' %}
+- {{ text }}
+{% else %}
+{% set comma = joiner(', ') %}
+- {% for value in values|sort %}{{ comma() }}:fa:`code-pull-request` :pull:`{{ value[1:] }}`{% endfor %}: {{ text|replace(":issue:", ":far:`circle-dot` :issue:") }}
+{% endif %}
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+
+No significant changes.
+
+{% else %}
+{% endif %}
+{% endfor %}
+{% else %}
+
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -113,6 +113,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "sphinx_changelog",
     "sphinx_click",
     "sphinx_copybutton",
     "sphinx_design",
@@ -152,6 +153,7 @@ root_doc = "index"
 # Sphinx document translation with sphinx gettext feature uses these settings:
 locale_dirs = ["locale/"]
 gettext_compact = False
+
 
 # -- Project information -----------------------------------------------------
 # See https://www.sphinx-doc.org/en/master/config.html#project-information
@@ -537,8 +539,9 @@ doctest_global_setup = "import geovista"
 # See https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 
 extlinks = {
-    "issue": ("https://github.com/bjlittle/geovista/issues/%s", "Issue #%s"),
-    "pull": ("https://github.com/bjlittle/geovista/pull/%s", "PR #%s"),
+    "issue": ("https://github.com/bjlittle/geovista/issues/%s", "#%s"),
+    "pull": ("https://github.com/bjlittle/geovista/pull/%s", "#%s"),
+    "user": ("https://github.com/%s", "@%s"),
 }
 
 

--- a/docs/src/reference/changelog.rst
+++ b/docs/src/reference/changelog.rst
@@ -1,14 +1,18 @@
-:orphan:
-
 .. _gv-changelog:
 
-🚧 :fa:`road` Changelog
-=======================
+:fa:`road` Changelog
+====================
 
-.. note::
-    :class: margin, dropdown, toggle-shown
+Release versions follow `Semantic Versioning <https://semver.org>`_
+i.e., ``<major>.<minor>.<patch>``.
 
-    Content marked with 🚧 indicates it's still under construction.
+Backward incompatible breaking changes will only be introduced in ``<major>``
+versions, with advance notice provided in the ``🔥 Deprecations`` section
+of a prior ``<minor>`` release.
 
+----
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum malesuada arcu sit amet porttitor ornare. Quisque ut.
+.. changelog::
+    :towncrier: ../../../
+    :towncrier-skip-if-empty:
+    :changelog_file: ../../../CHANGELOG.rst

--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -25,16 +25,27 @@ Consult our reference material for no fuss facts about ``geovista``.
 
         Package metadata.
 
-    .. grid-item-card:: Environment Variables
+    .. grid-item-card:: API Reference
         :class-title: custom-title
         :class-body: custom-body
-        :link: gv-environment
+        :link: gv-api
         :link-type: ref
-        :img-top: ../_static/images/icons/environment.svg
+        :img-top: ../_static/images/icons/api.svg
         :class-img-top: dark-light
         :class-card: sd-rounded-3
 
-        Package controls.
+        Behaviour and state docstrings.
+
+    .. grid-item-card:: Changelog
+        :class-title: custom-title
+        :class-body: custom-body
+        :link: gv-changelog
+        :link-type: ref
+        :img-top: ../_static/images/icons/changelog.svg
+        :class-img-top: dark-light
+        :class-card: sd-rounded-3
+
+        In-depth release notes.
 
     .. grid-item-card:: CLI
         :class-title: custom-title
@@ -47,16 +58,16 @@ Consult our reference material for no fuss facts about ``geovista``.
 
         Command line interface.
 
-    .. grid-item-card:: Key Bindings
+    .. grid-item-card:: Environment Variables
         :class-title: custom-title
         :class-body: custom-body
-        :link: gv-bindings
+        :link: gv-environment
         :link-type: ref
-        :img-top: ../_static/images/icons/bindings.svg
+        :img-top: ../_static/images/icons/environment.svg
         :class-img-top: dark-light
         :class-card: sd-rounded-3
 
-        GUI hot-keys.
+        Package controls.
 
     .. grid-item-card:: Glossary
         :class-title: custom-title
@@ -69,6 +80,17 @@ Consult our reference material for no fuss facts about ``geovista``.
 
         Jargon buster.
 
+    .. grid-item-card:: Key Bindings
+        :class-title: custom-title
+        :class-body: custom-body
+        :link: gv-bindings
+        :link-type: ref
+        :img-top: ../_static/images/icons/bindings.svg
+        :class-img-top: dark-light
+        :class-card: sd-rounded-3
+
+        GUI hot-keys.
+
     .. grid-item-card:: Tags
         :class-title: custom-title
         :class-body: custom-body
@@ -79,17 +101,6 @@ Consult our reference material for no fuss facts about ``geovista``.
         :class-card: sd-rounded-3
 
         Themed content tags.
-
-    .. grid-item-card:: 🚧 Changelog
-        :class-title: custom-title
-        :class-body: custom-body
-        :link: gv-changelog
-        :link-type: ref
-        :img-top: ../_static/images/icons/changelog.svg
-        :class-img-top: dark-light
-        :class-card: sd-rounded-3
-
-        In depth release details.
 
     .. grid-item-card:: 🚧 What's New
         :class-title: custom-title
@@ -102,27 +113,16 @@ Consult our reference material for no fuss facts about ``geovista``.
 
         Release highlights.
 
-    .. grid-item-card:: API Reference
-        :class-title: custom-title
-        :class-body: custom-body
-        :link: gv-api
-        :link-type: ref
-        :img-top: ../_static/images/icons/api.svg
-        :class-img-top: dark-light
-        :class-card: sd-rounded-3
-
-        Behaviour and state docstrings.
-
 
 .. toctree::
     :maxdepth: 1
     :hidden:
 
     about
-    environment
-    cli/index
-    bindings
-    glossary
-    changelog
-    whatsnew
     generated/api/geovista/index
+    changelog
+    cli/index
+    environment
+    glossary
+    bindings
+    whatsnew

--- a/docs/src/reference/whatsnew.rst
+++ b/docs/src/reference/whatsnew.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _gv-whatsnew:
 
 🚧 :fa:`wand-magic-sparkles` What's New

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,3 +288,82 @@ where = ["src"]
 write_to = "src/geovista/_version.py"
 local_scheme = "dirty-tag"
 version_scheme = "release-branch-semver"
+
+
+[tool.towncrier]
+package = "geovista"
+package_dir = "src"
+filename = "CHANGELOG.rst"
+directory = "changelog"
+title_format = "v{version} ({project_date})"
+template = "changelog/template.rst"
+
+#
+# the order here defines the rendered changelog order
+#
+[[tool.towncrier.type]]
+# Removals and backward incompatible breaking changes.
+directory = "breaking"
+name = "💣 Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Declaration of removals and backward incompatible changes.
+directory = "deprecation"
+name = "🔥 Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+# New behaviours, capability, public API etc
+directory = "feature"
+name = "✨ New Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+# New behaviours in existing features e.g., performance
+directory = "enhancement"
+name = "🚀 Enhancements"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Correction to undesired behaviours.
+directory = "bugfix"
+name = "🐛 Bug Fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Package dependancy removals, additions, pins etc
+directory = "dependency"
+name = "🔗 Dependencies"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Notable changes to the documentation structure, content, render or build
+directory = "documentation"
+name = "📚 Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Miscellaneos internal and maintentance changes.
+directory = "internal"
+name = "💼 Internal"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Celebrate our awesome community members.
+directory = "community"
+name = "🌱 Community"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Changes that affect contributors e.g., standards, conventions,
+# running tests, building docs, environments etc
+directory = "contributor"
+name = "🛠️ Contributor Infrastructure"
+showcontent = true
+
+[[tool.towncrier.type]]
+# Catch all for items that don't fit elsewhere.
+directory = "misc"
+name = "🧰 Miscellaneous"
+showcontent = true


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds `changelog` support with [towncrier](https://github.com/twisted/towncrier) to automate the generation of pre-release news fragments within the `changelog` along with the already published release `changelog`.

The documentation `reference` section cards have also been reorganised.

How contributors use the `changelog` workflow will be documented in a follow-on pull-request along with the retrospective news fragments for all merged pull-request post 0.5.0.

Additionally, automated governance of `changelog` news fragments contributed within pull-requests will also be introduced as a follow-on pull-request. 

---
