### PR TITLE
add temporary max pin for towncrier

### DIFF
--- a/changelog/1039.dependency.rst
+++ b/changelog/1039.dependency.rst
@@ -1,0 +1,2 @@
+Introduced temporary maximum pin ``towncrier<24.7.0`` due to breaking change
+for ``sphinx-changelog``. (:user:`bjlittle`)

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -56,6 +56,7 @@ dependencies:
   - sphinx-autoapi >=3.0.0
   - sphinx-book-theme >=1.1.3
   - sphinx_changelog
+  - towncrier <24.7.0
   - sphinx-click
   - sphinx-copybutton
   - sphinx-design

--- a/requirements/pypi-optional-docs.txt
+++ b/requirements/pypi-optional-docs.txt
@@ -6,6 +6,7 @@ sphinx_design
 sphinx-autoapi >=3.0.0
 sphinx-book-theme >=1.1.3
 sphinx-changelog
+towncrier <24.7.0
 sphinx-click
 sphinx-copybutton
 sphinx-gallery >=0.16


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The recent `towncrier` 24.7.0 release contains breaking changes to either API which directly impacts the `sphinx-chagnelog` directive.

Introducing this temporary maximum pin in the meantime, and I'll notify or push a pull-request fix to `sphinx-changelog`. Once the fix to `sphinx-changelog` is banked and released, we can then remove this maximum pin and then also introduce a new minimum pin to `sphinx-changelog`.

---
