### PR TITLE
unpin towncrier

### DIFF
--- a/changelog/1067.dependency.rst
+++ b/changelog/1067.dependency.rst
@@ -1,0 +1,2 @@
+Unpinned ``towncrier`` and introduced minimum pin ``sphinx-changelog>=1.6.0``.
+(:user:`bjlittle`)

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -56,8 +56,8 @@ dependencies:
   - sphinx >=7.3
   - sphinx-autoapi >=3.2.0
   - sphinx-book-theme >=1.1.3
-  - sphinx_changelog
-  - towncrier <24.7.0
+  - sphinx_changelog >=1.6.0
+  - towncrier
   - sphinx-click
   - sphinx-copybutton
   - sphinx-design

--- a/requirements/pypi-optional-docs.txt
+++ b/requirements/pypi-optional-docs.txt
@@ -5,8 +5,8 @@ sphinx >=7.3
 sphinx_design
 sphinx-autoapi >=3.2.0
 sphinx-book-theme >=1.1.3
-sphinx-changelog
-towncrier <24.7.0
+sphinx-changelog >=1.6.0
+towncrier
 sphinx-click
 sphinx-copybutton
 sphinx-gallery >=0.16


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request removes the defensive maximum pin to `towncrier` in light of the fix and release of [sphinx-changelog v1.6.0](https://github.com/OpenAstronomy/sphinx-changelog/releases/tag/v1.6.0).

As a result we now have the minimum pin `sphinx-changelog>1.6.0`.

---
