### PR TITLE
gha: ci-changelog don't cancel-in-progress concurrency

### DIFF
--- a/.github/workflows/ci-changelog.yml
+++ b/.github/workflows/ci-changelog.yml
@@ -25,7 +25,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   changelog:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request explicitly revokes the `cancel-in-progress` of concurrent GHA workflow tasks for the `ci-changelog`.

I believe this is the last wrinkle in this workflow with regards to race conditions between the `ci-changelog` and `ci-label` and the user applying the label prior to pushing the pull-request.

... we'll see :eyes: 

---
