### PR TITLE
gha: change ci-changelog concurrency and event trigger events

### DIFF
--- a/.github/workflows/ci-changelog.yml
+++ b/.github/workflows/ci-changelog.yml
@@ -16,16 +16,14 @@ on:
   push:
     branches:
       - "!main"
-      - "v*x"
-      - "!conda-lock-auto-update"
-      - "!pre-commit-ci-update-config"
-      - "!dependabot/*"
+    tags:
+      - "!v*"
 
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   changelog:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Still experiencing some `Canceling since a higher priority waiting request` issues, that causes the workflow queued job to be cancelled and expected pending jobs not to be scheduled and ran.

Experimenting with changes based on similar community chatter on this issue, as this GHA actual behaviour isn't as expected in certain circumstances.

---
