### PR TITLE
drop tox usage within ci-locks gha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,5 @@ updates:
       - "bot"
       - "skip changelog"
     commit-message:
-      prefix: "ci: "
+      prefix: "chore: "
       include: "scope"

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -59,9 +59,6 @@ jobs:
       uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
       with:
         miniforge-version: latest
-        channels: conda-forge,defaults
-        channel-priority: true
-        auto-update-conda: true
         activate-environment: ${{ env.ENV_NAME }}
         use-only-tar-bz2: false
 
@@ -70,21 +67,21 @@ jobs:
       with:
         cache_period: ${{ env.CACHE_PERIOD }}
         env_name: ${{ env.ENV_NAME }}
-        install_packages: "pip 'tox<4'"
+        install_packages: "conda-lock jinja2"
 
     - name: "conda info"
       run: |
         conda info
         conda list
 
-    - name: "tox cache"
-      uses: ./.github/workflows/composite/tox-cache
-
     - name: "lock (${{ matrix.version }})"
       env:
         VTK_BUILD: "  - vtk=*=qt_*"
+      working-directory: requirements/locks
       run: |
-        tox -e ${{ matrix.version }}-lock
+        python -c 'from sys import version_info as v; open("../geovista.yml", "a").write(f"\n  - python ={v.major}.{v.minor}\n${{ env.VTK_BUILD }}\n")'
+        conda-lock --mamba --channel conda-forge --kind explicit --file ../geovista.yml --platform linux-64 --filename-template "${{ matrix.version }}-{platform}.txt"
+        python lock2yaml.py ${{ matrix.version }}
 
     - uses: actions/upload-artifact@v4
       with:
@@ -127,7 +124,7 @@ jobs:
         commit-message: "updated conda lock files"
         branch: conda-lock-auto-update
         delete-branch: true
-        title: "[geovista.ci] conda lock auto-update"
+        title: "chore: bump conda lock files"
         body: |
           🤖 Bleep! Bloop!
 

--- a/changelog/1124.contributor.rst
+++ b/changelog/1124.contributor.rst
@@ -1,0 +1,4 @@
+Dropped the use of ``tox`` to render lock file updates within the ``ci-locks``
+:fab:`github` Action due to incompatibilites between the pinned
+`tox-conda <https://github.com/tox-dev/tox-conda>`__ plugin and the modern
+:fab:`github` runner environment. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This situation was somewhat overdue as the [tox-conda](https://github.com/tox-dev/tox-conda) plugin has been pinned for a long time due to the lack of maintenance effort to migrate the plugin to support `tox>=4.x`.

For me this is the end of the road for using `conda` within `tox`.

It's time to replace it with alternative infrastructure ...

---
