### PR TITLE
patch: fix rasterio 1.4.x regression

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -50,7 +50,7 @@ jobs:
         posargs: ["--xvfb-backend xvfb --durations=10"]
         include:
           - version: "py312"
-            coverage: "--cov-report=xml --cov=geovista"
+            coverage: "--cov-report= --cov=geovista"
 
     steps:
     - uses: actions/checkout@v4
@@ -131,13 +131,13 @@ jobs:
     - name: "prepare coverage"
       if: ${{ matrix.coverage }}
       run: |
-        mv .coverage .coverage${{ strategy.job-index }}
+        mv .coverage ci-test-coverage${{ strategy.job-index }}
 
     - if: ${{ matrix.coverage }}
       uses: actions/upload-artifact@v4
       with:
         name: coverage-artifacts-${{ github.job }}-${{ strategy.job-index }}
-        path: ${{ github.workspace }}/.coverage*
+        path: ${{ github.workspace }}/ci-test-coverage*
 
 
   coverage:
@@ -169,7 +169,7 @@ jobs:
 
       - name: "create coverage report"
         run: |
-          coverage combine .coverage*
+          coverage combine ci-test-coverage*
           coverage xml --omit=*/_version.py
 
       - name: "upload coverage report"

--- a/src/geovista/examples/rectilinear/from_1d__oisst.py
+++ b/src/geovista/examples/rectilinear/from_1d__oisst.py
@@ -18,8 +18,8 @@ Creates a mesh from 1-D latitude and longitude rectilinear cell bounds.
 The resulting mesh contains quad cells.
 
 The example uses NOAA/NECI 1/4° Daily Optimum Interpolation Sea Surface Temperature
-(OISST) v2.1 Advanced Very High Resolution Radiometer (AVHRR) gridded data
-(https://doi.org/10.25921/RE9P-PT57). The data targets the mesh faces/cells.
+(OISST) v2.1 Advanced Very High Resolution Radiometer (AVHRR) gridded data.
+The data targets the mesh faces/cells.
 
 Note that, a threshold is also applied to remove land ``NaN`` cells, and a
 NASA Blue Marble base layer is rendered along with Natural Earth coastlines.

--- a/src/geovista/examples/rectilinear/from_1d__oisst_eqc.py
+++ b/src/geovista/examples/rectilinear/from_1d__oisst_eqc.py
@@ -18,8 +18,8 @@ Creates a mesh from 1-D latitude and longitude rectilinear cell bounds.
 The resulting mesh contains quad cells.
 
 The example uses NOAA/NECI 1/4° Daily Optimum Interpolation Sea Surface Temperature
-(OISST) v2.1 Advanced Very High Resolution Radiometer (AVHRR) gridded data
-(https://doi.org/10.25921/RE9P-PT57). The data targets the mesh faces/cells.
+(OISST) v2.1 Advanced Very High Resolution Radiometer (AVHRR) gridded data.
+The data targets the mesh faces/cells.
 
 Note that, a threshold is also applied to remove land ``NaN`` cells, and a
 NASA Blue Marble base layer is rendered along with Natural Earth coastlines.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request addresses a regression in the behaviour of the recently released `rasterio` [1.4.0](https://github.com/rasterio/rasterio/releases/tag/1.4.0) (and [1.4.1](https://github.com/rasterio/rasterio/releases/tag/1.4.1) patch).

For further details see https://github.com/rasterio/rasterio/issues/3191.

Essentially `geovista` now explicitly manages the shape of data passed in and out of the [rasterio.transform.xy](https://rasterio.readthedocs.io/en/stable/api/rasterio.transform.html#rasterio.transform.xy) function.

There was an implicit user assumption that `rasterio` would maintain the shape of data passed through `rasterio.transform.xy`, and this assumption held prior to 1.4.0. 

`rasterio` 1.4.0 then enforced its expectation that data passed to `rasterio.transform.xy` was only 1-D.

The `rasterio` 1.4.1 patch reverted this regression in behaviour, thus allowing (for `geovista`) 2-D data to be passed into `rasterio.transform.xy` again. However, the resultant transformed data was no longer 2-D. This subsequently caused an issue for the `geovista.bridge`.

Rather than pin or wait for `rasterio` to possibly patch again, we now control the shape of the data ourselves.

Closes #1131

---
