### PR TITLE
increase frequency of ci-locks gha cron

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -10,8 +10,8 @@ name: ci-locks
 on:
   workflow_dispatch:
   schedule:
-    # every sunday @ 00h03
-    - cron: "3 0 * * 0"
+    # every 2nd day @ 00h03
+    - cron: "3 0 */2 * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/changelog/1133.internal.rst
+++ b/changelog/1133.internal.rst
@@ -1,0 +1,2 @@
+Merged back ``0.5.x`` release feature branch into ``main`` for ``0.5.2``.
+(:user:`bjlittle`)

--- a/changelog/1136.contributor.rst
+++ b/changelog/1136.contributor.rst
@@ -1,0 +1,3 @@
+Changed the frequency of the ``ci-locks`` :fab:`github` Action ``cron``
+to be every 2nd day to assist with earlier detection of breaking
+regressions in package dependencies, see :issue:`1131`. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request increases the frequency of the `ci-locks` GHA cron to run every 2nd day.

This is in response to the recent `rasterio` behaviour regression (see #1131) which caused disruption of the `pyvista` pull-request workflow due to failing `geovista` integration tests.

I'd rather that `geovista` tests and updates its dependencies little and often. We can monitor and review the timeline frequency, but I'm keen to limit disruptions on `pyvista` as much as possible.

@banesullivan @tkoyama010 :+1: 

---
