### PR TITLE
migrate to >=py311 enum.StrEnum usage

### DIFF
--- a/changelog/1144.internal.rst
+++ b/changelog/1144.internal.rst
@@ -1,0 +1,5 @@
+Refactored ``Preference`` enums to use
+`enum.StrEnum <https://docs.python.org/3/library/enum.html#enum.StrEnum>`__ and
+`enum.auto <https://docs.python.org/3/library/enum.html#enum.auto>`__ as
+``py311`` is now the minimum supported version, see :pull:`1118`.
+(:user:`bjlittle`)

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -14,7 +14,7 @@ Notes
 from __future__ import annotations
 
 from collections.abc import Iterable
-from enum import Enum
+from enum import StrEnum, auto
 import importlib
 import pkgutil
 import sys
@@ -220,25 +220,8 @@ class MixinStrEnum:
         """
         return tuple([member.value for member in cls])
 
-    def __str__(self) -> str:
-        """Serialize enumeration name.
 
-        Returns
-        -------
-        str
-            The enumeration name.
-
-        Notes
-        -----
-        .. versionadded:: 0.3.0
-
-        """
-        # TODO @bjlittle: Remove when minimum supported python version is 3.11.
-        return f"{self.name.lower()}"
-
-
-# TODO @bjlittle: Use StrEnum and auto when minimum supported python version is 3.11.
-class Preference(MixinStrEnum, Enum):
+class Preference(MixinStrEnum, StrEnum):
     """Enumeration of common mesh geometry preferences.
 
     Notes
@@ -247,8 +230,8 @@ class Preference(MixinStrEnum, Enum):
 
     """
 
-    CELL = "cell"
-    POINT = "point"
+    CELL = auto()
+    POINT = auto()
 
 
 def active_kernel() -> bool:

--- a/src/geovista/geodesic.py
+++ b/src/geovista/geodesic.py
@@ -14,7 +14,7 @@ Notes
 from __future__ import annotations
 
 from collections.abc import Iterable
-from enum import Enum
+from enum import StrEnum, auto
 from typing import TYPE_CHECKING, TypeAlias
 import warnings
 
@@ -123,8 +123,7 @@ PREFERENCE: str = "center"
 """The default bounding-box preference."""
 
 
-# TODO @bjlittle: Use StrEnum and auto when minimum supported python version is 3.11.
-class EnclosedPreference(MixinStrEnum, Enum):
+class EnclosedPreference(MixinStrEnum, StrEnum):
     """Enumeration of mesh geometry enclosed preferences.
 
     Notes
@@ -133,9 +132,9 @@ class EnclosedPreference(MixinStrEnum, Enum):
 
     """
 
-    CELL = "cell"
-    CENTER = "center"
-    POINT = "point"
+    CELL = auto()
+    CENTER = auto()
+    POINT = auto()
 
 
 class BBox:  # numpydoc ignore=PR01

--- a/src/geovista/pantry/data.py
+++ b/src/geovista/pantry/data.py
@@ -14,7 +14,7 @@ Notes
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum, auto
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
@@ -69,8 +69,7 @@ PANTRY_DATA: str = "pantry/data"
 """The registry key for the pantry data."""
 
 
-# TODO @bjlittle: Use StrEnum and auto when minimum supported python version is 3.11.
-class CloudPreference(MixinStrEnum, Enum):
+class CloudPreference(MixinStrEnum, StrEnum):
     """Enumeration of mesh types for cloud amount.
 
     Notes
@@ -79,11 +78,11 @@ class CloudPreference(MixinStrEnum, Enum):
 
     """
 
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    VERY_HIGH = "very_high"
-    MESH = "mesh"
+    LOW = auto()
+    MEDIUM = auto()
+    HIGH = auto()
+    VERY_HIGH = auto()
+    MESH = auto()
 
 
 @dataclass(frozen=True)

--- a/src/geovista/search.py
+++ b/src/geovista/search.py
@@ -14,7 +14,7 @@ Notes
 from __future__ import annotations
 
 from collections.abc import Iterable
-from enum import Enum
+from enum import StrEnum, auto
 from typing import TYPE_CHECKING
 
 import lazy_loader as lazy
@@ -64,8 +64,7 @@ KDTREE_PREFERENCE: str = "point"
 """The default search preference."""
 
 
-# TODO @bjlittle: Use StrEnum and auto when minimum supported python version is 3.11.
-class SearchPreference(MixinStrEnum, Enum):
+class SearchPreference(MixinStrEnum, StrEnum):
     """Enumeration of mesh geometry search preferences.
 
     Notes
@@ -74,8 +73,8 @@ class SearchPreference(MixinStrEnum, Enum):
 
     """
 
-    CENTER = "center"
-    POINT = "point"
+    CENTER = auto()
+    POINT = auto()
 
 
 class KDTree:  # numpydoc ignore=PR01

--- a/tests/common/test_Preference.py
+++ b/tests/common/test_Preference.py
@@ -24,6 +24,11 @@ def test_members():
     assert tuple([member.value for member in Preference]) == EXPECTED_VALUES
 
 
+def test_members___str__():
+    """Test expected enumeration members string."""
+    assert tuple([str(member) for member in Preference]) == EXPECTED_VALUES
+
+
 def test_values():
     """Test expected enumeration member values."""
     assert Preference.values() == EXPECTED_VALUES

--- a/tests/geodesic/test_EnclosedPreference.py
+++ b/tests/geodesic/test_EnclosedPreference.py
@@ -24,6 +24,11 @@ def test_members():
     assert tuple([member.value for member in EnclosedPreference]) == EXPECTED_VALUES
 
 
+def test_members___str__():
+    """Test expected enumeration members string."""
+    assert tuple([str(member) for member in EnclosedPreference]) == EXPECTED_VALUES
+
+
 def test_values():
     """Test expected enumeration member values."""
     assert EnclosedPreference.values() == EXPECTED_VALUES

--- a/tests/search/test_SearchPreference.py
+++ b/tests/search/test_SearchPreference.py
@@ -24,6 +24,11 @@ def test_members():
     assert tuple([member.value for member in SearchPreference]) == EXPECTED_VALUES
 
 
+def test_members___str__():
+    """Test expected enumeration members string."""
+    assert tuple([str(member) for member in SearchPreference]) == EXPECTED_VALUES
+
+
 def test_values():
     """Test expected enumeration member values."""
     assert SearchPreference.values() == EXPECTED_VALUES


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

After adopting [Scientific Python SPEC-0](https://scientific-python.org/specs/spec-0000/) and dropping support of `py310`, we're now free to adopt [enum.StrEnum](https://docs.python.org/3/library/enum.html#enum.StrEnum) and [enum.auto](https://docs.python.org/3/library/enum.html#enum.auto) and thus purge some tech debt.

---
