### PR TITLE
docs: optimise building with html-tutorial support

### DIFF
--- a/changelog/1146.contributor.rst
+++ b/changelog/1146.contributor.rst
@@ -1,0 +1,5 @@
+Optimised the documentation building workflow by providing control of whether
+:ref:`tutorial <gv-tutorials>` ``jupyter notebook`` code cells are executed.
+By default, code cells will only be executed when building the documentation
+with either the ``make html`` or ``make html-tutorial`` commands.
+(:user:`bjlittle`)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: Makefile clean doctest help html-docstring html-gallery html-noplot linkcheck serve-html
+.PHONY: Makefile clean doctest help html-docstring html-gallery html-noplot html-tutorial linkcheck serve-html
 
 clean:
 	-rm -rf $(BUILDDIR)
@@ -28,19 +28,22 @@ clean:
 	-rm -f $(SOURCEDIR)/gallery_carousel.txt
 
 doctest:
-	@$(SPHINXBUILD) -b doctest -D plot_gallery=False -D plot_docstring=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/doctest"
+	@$(SPHINXBUILD) -b doctest -D plot_docstring=False -D plot_gallery=False -D plot_tutorial=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/doctest"
 
 html-docstring:
-	@$(SPHINXBUILD) -b html -D plot_gallery=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
+	@$(SPHINXBUILD) -b html -D plot_gallery=False -D plot_tutorial=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 html-gallery:
-	@$(SPHINXBUILD) -b html -D plot_docstring=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
+	@$(SPHINXBUILD) -b html -D plot_docstring=False -D plot_tutorial=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 html-noplot:
+	@$(SPHINXBUILD) -b html -D plot_docstring=False -D plot_gallery=False -D plot_tutorial=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
+
+html-tutorial:
 	@$(SPHINXBUILD) -b html -D plot_docstring=False -D plot_gallery=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 linkcheck:
-	@$(SPHINXBUILD) -b linkcheck -D plot_docstring=False -D plot_gallery=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck"
+	@$(SPHINXBUILD) -b linkcheck -D plot_docstring=False -D plot_gallery=False -D plot_tutorial=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck"
 
 # Spin up a local http server to view the rendered documentation.
 # This is required for interactive examples to work.

--- a/docs/src/tutorials/index.rst
+++ b/docs/src/tutorials/index.rst
@@ -19,7 +19,8 @@ A collection of themed practical lessons to work though.
 
     .. grid-item-card::
         :text-align: center
-        :link: region-manifold-extraction.html
+        :link: gv-tutorials-region-manifold-extraction
+        :link-type: ref
 
         .. image:: ../_static/images/region-manifold-extraction.png
             :alt: Region Manifold Extraction


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Been meaning to do this for a while now ...

This pull-request optimises documentation building by adding an option to control whether the tutorial jupyter notebook code cells are executed. Not executing notebook cells can make a significant saving at build time, as typically our notebooks will be rich in image rendering, and as we add more content this will become more expensive.

This is a welcome optimisation, particularly when using the `make html-noplot` workflow e.g., building the docs to eyeball a pull-request changelog contribution should be a slick experience for a fast contributor turnaround.

Note that, we now have the following behaviours:

| Command | Doc-string Images | Gallery Images | Tutorial Images |
| :---: | :---: | :---: | :---: |
| `make doctest` | ❎ | ❎ | ❎ |
| `make html` | ☑️ | ☑️ | ☑️ |
| `make html-docstring` | ☑️ | ❎ | ❎ |
| `make html-gallery` | ❎ | ☑️ | ❎ |
| `make html-noplot` | ❎ | ❎ | ❎ |
| `make html-tutorial` (†) | ❎ | ❎ | ☑️ |
| `make linkcheck` | ❎ | ❎ | ❎ |

† - This is a new `Makefile` build command.

---
