### PR TITLE
docs: use myst-nb cache when building jupyter notebooks

### DIFF
--- a/changelog/1147.contributor.rst
+++ b/changelog/1147.contributor.rst
@@ -1,0 +1,4 @@
+Adopted caching of :ref:`tutorial <gv-tutorials>` ``jupyter notebook`` outputs
+when building the documentation. The cache will only be cleared with either
+the ``make clean-cache`` or ``make clean-all`` commands. The ``make clean``
+command will **not** clear the cache. (:user:`bjlittle`)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,15 +17,20 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: Makefile clean doctest help html-docstring html-gallery html-noplot html-tutorial linkcheck serve-html
+.PHONY: Makefile clean clean-cache clean-all doctest help html-docstring html-gallery html-noplot html-tutorial linkcheck serve-html
 
 clean:
-	-rm -rf $(BUILDDIR)
+	-rm -rf $(BUILDDIR)/*
 	-rm -rf $(SOURCEDIR)/generated
 	-rm -rf $(SOURCEDIR)/reference/generated
 	-rm -rf $(SOURCEDIR)/tags
 	-rm -f $(SOURCEDIR)/sg_execution_times.rst
 	-rm -f $(SOURCEDIR)/gallery_carousel.txt
+
+clean-cache:
+	-rm -rf $(BUILDDIR)/.jupyter_cache
+
+clean-all: clean-cache clean
 
 doctest:
 	@$(SPHINXBUILD) -b doctest -D plot_docstring=False -D plot_gallery=False -D plot_tutorial=False -d "$(BUILDDIR)/doctrees" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/doctest"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -280,8 +280,7 @@ togglebutton_hint_hide = "Click to hide"
 # myst-nb options ------------------------------------------------------------
 # See https://myst-nb.readthedocs.io/en/latest/configuration.html
 
-# TODO @bjlittle: investigate jupyter-cache mode
-nb_execution_mode = "auto"
+nb_execution_mode = "cache"
 nb_execution_raise_on_error = True
 nb_execution_timeout = -1
 nb_number_source_lines = True


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request uses the [cache](https://myst-nb.readthedocs.io/en/latest/computation/execute.html#cache-execution-outputs) support provided by `myst-nb` to optimise the building of tutorial `jupyter` notebooks.

The cache will only be cleared with the new commands `make clean-cache` and `make clean-all`.

The `make clean` command will not clear the cache.

---
