### PR TITLE
ci-changelog get pr number

### DIFF
--- a/.github/workflows/ci-changelog.yml
+++ b/.github/workflows/ci-changelog.yml
@@ -1,9 +1,7 @@
 # Reference:
 #   - https://github.com/actions/checkout
 #   - https://github.com/actions/setup-python
-#   - https://github.com/jwalton/gh-find-current-pr
 #   - https://github.com/snnaplab/get-labels-action
-#   - https://github.com/jitterbit/get-changed-files (don't use - abandoned repo?)
 #   - https://github.com/dorny/paths-filter
 
 
@@ -41,10 +39,6 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: 'get PR number'
-        uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b
-        id: pr
-
       - name: 'get PR labels'
         uses: snnaplab/get-labels-action@f426df40304808ace3b5282d4f036515f7609576
 
@@ -61,7 +55,7 @@ jobs:
         if: ${{ ! contains(fromJSON(env.LABELS), 'skip changelog') }}
         env:
           CHANGELOG: "${{ steps.changes.outputs.changelog_files }}"
-          PR: "${{ steps.pr.outputs.number }}"
+          PR: "${{ github.event.number }}"
           SCRIPTS: "./.github/scripts"
         run: |
           python -m pip install click towncrier

--- a/changelog/1155.internal.rst
+++ b/changelog/1155.internal.rst
@@ -1,0 +1,2 @@
+Reverted use of the `jwalton/gh-find-current-pr <https://github.com/jwalton/gh-find-current-pr>`__
+:fab:`github` Action within the ``ci-changelog`` :fab:`github` Action. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request reverts the use of the [jwalton/gh-find-current-pr](https://github.com/jwalton/gh-find-current-pr) GHA within the `ci-changelog` as it was not working for a pull-request from forked `geovista` repository, reference #1152

There are various other GHAs that purport to do this, but sadly this doesn't seem to be the case after experimentation.

Given that the `ci-changelog` GHA will only be expected to execute based on a `pull_request` event and not a `push`, we should be able to simply use `github.event.number` or `github.event.pull_request.number` instead.

---
