### PR TITLE
temporary pin uber/h3-py to avoid 4.x breaking behaviour

### DIFF
--- a/changelog/1040.dependency.rst
+++ b/changelog/1040.dependency.rst
@@ -1,2 +1,2 @@
-Bumped ``mambaforge`` from 22.9 to 23.11 for ``readthedocs`` and introduced
-minimum pin ``lazy_loader >=0.4``. (:user:`bjlittle`)
+Bumped ``mambaforge`` from ``22.9`` to ``23.11`` for ``readthedocs`` and
+introduced minimum pin ``lazy_loader >=0.4``. (:user:`bjlittle`)

--- a/changelog/1053.documentation.rst
+++ b/changelog/1053.documentation.rst
@@ -1,2 +1,2 @@
-Adopted `sphinx-autoapi <https://github.com/readthedocs/sphinx-autoapi>`__ 3.2.1 templates.
-(:user:`bjlittle`)
+Adopted `sphinx-autoapi <https://github.com/readthedocs/sphinx-autoapi>`__
+``3.2.1`` templates. (:user:`bjlittle`)

--- a/changelog/1157.dependency.rst
+++ b/changelog/1157.dependency.rst
@@ -1,0 +1,2 @@
+Introduced temporary minimum pin ``h3-py ==3.7.7`` to avoid breaking major
+release ``4.x`` behaviour. (:user:`bjlittle`)

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -505,6 +505,7 @@ linkcheck_ignore = [
     "https://www.mtu.edu/geo/community/seismology/learn/earthquake-measure/magnitude/",
     "https://www.usgs.gov/programs/earthquake-hazards",
     "https://www.ncei.noaa.gov/products/optimum-interpolation-sst",
+    "https://earthexplorer.usgs.gov",
 ]
 linkcheck_retries = 3
 

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -43,7 +43,7 @@ dependencies:
 
 # examples dependencies (optional)
   - fastparquet
-  - h3-py
+  - h3-py ==3.7.7
   - pandas
   - pyarrow
   - rasterio >=1.3

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,5 +1,5 @@
 fastparquet
-h3
+h3 ==3.7.7
 pandas
 pyarrow
 rasterio >=1.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-requeste introduces a temporary pin to `h3-py ==3.7.7` in order to avoid breaking behaviour introduced in 4.1.0.

Weirdly they appear to have skipped the 4.0.0 release :confused: 

Merging this pin to `main` will unblock the `pyvista` integration workflow. We can then fix and patch `geovista` (introducing a minimum pin) to work with `h3-py` `>=4.x`

Note that, this breaking behaviour only appears to happen with PyPI dependencies, which install 4.x, whereas the `conda` lock files don't resolve for 4.x and instead remain with the working 3.7.7. 

Hence why the `ci-locks-test` workflow didn't trip :angry: 

---
