### PR TITLE
gha: generate issue report for ci-tests-pypi only on schedule

### DIFF
--- a/.github/workflows/ci-tests-pypi.yml
+++ b/.github/workflows/ci-tests-pypi.yml
@@ -72,7 +72,7 @@ jobs:
         pytest --xvfb-backend xvfb --fail_extra_image_cache --generated_image_dir test_images
 
     - name: "report failure"
-      if: failure()
+      if: failure() && github.event_name == 'schedule'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

There is no need to generate an associated GH issue for a failed `ci-tests-pypi` GHA run triggered from a pull-request. 

This level of alert is only necessary to notify contributors when the GHA fails when scheduled by the `cron`.

---
