### PR TITLE
update dependabot group names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,9 @@ updates:
       - "/"
       - "/.github/workflows/composite/*"
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"
     groups:
-      dependencies:
+      gha:
         patterns:
           - "*"
     labels:
@@ -29,7 +28,7 @@ updates:
       interval: "weekly"
       day: "sunday"
     groups:
-      dependencies:
+      pip:
         patterns:
           - "*"
     labels:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request changes the `dependabot` group names, which will result in clearer `dependabot` pull-request titles, now that we use `dependabot` for more than one package-ecosystem i.e., `github-actions` and `pip`.

---
