### PR TITLE
add min pin h3>=4.1

### DIFF
--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -42,7 +42,7 @@ dependencies:
 
 # examples dependencies (optional)
   - fastparquet
-  - h3-py
+  - h3-py >=4.1
   - pandas
   - pyarrow
   - rasterio >=1.3

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,5 +1,5 @@
 fastparquet
-h3
+h3 >=4.1
 pandas
 pyarrow
 rasterio >=1.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds the minimum pin for `h3 >=4.1`. This is the root of the `0.5.3` patch.

Following this, the lock files will require to be resolved to enforce the minimum pin along with a fix to account for the change in the 4.x API behaviour.

---
