### PR TITLE
drop optional pyarrow for pandas 3.x

### DIFF
--- a/changelog/1178.dependency.rst
+++ b/changelog/1178.dependency.rst
@@ -1,0 +1,2 @@
+Dropped the optional ``pyarrow`` dependency as ``pandas >2.2.0`` no longer
+issues a ``DeprecationWarning``. (:user:`bjlittle`)

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -45,7 +45,6 @@ dependencies:
   - fastparquet
   - h3-py >=4.1
   - pandas
-  - pyarrow
   - rasterio >=1.3
 
 # documentation dependencies (optional)

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,5 +1,4 @@
 fastparquet
 h3 >=4.1
 pandas
-pyarrow
 rasterio >=1.3


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request drops the optional `pyarrow` package.

This package was only added to remove the following `DeprecationWarning` being issued by `pandas` 2.2.0 (see #657):

```
DeprecationWarning: 
Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
but was not found to be installed on your system.
If this would cause problems for you,
please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```

However, from reading issue https://github.com/pandas-dev/pandas/issues/54466 which is collating community feedback, concerns were raised about the increased footprint from installing `pyarrow`. 

Subsequently, this `DeprecationWarning` was removed in `pandas` patch release 2.2.1 and included as an optional install i.e., `pip install pandas[pyarrow]` (see [here](https://github.com/pandas-dev/pandas/issues/54466) and [here](https://pandas.pydata.org/pandas-docs/version/2.2.1/whatsnew/v2.2.1.html#enhancements)).

As a result, we can drop the inclusion of `pyarrow`, which is also a blocker in our `py313` support (see [here](https://github.com/bjlittle/geovista/actions/runs/11554155411/job/32156786343)) :pray: 

---
