### PR TITLE
deps: enforce rasterio >=1.4.2 min pin

### DIFF
--- a/changelog/1188.dependency.rst
+++ b/changelog/1188.dependency.rst
@@ -1,0 +1,2 @@
+Introduced minimum pin ``rasterio >=1.4.2`` to support ``gdal >=3.10.0``.
+(:user:`bjlittle`)

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -45,7 +45,7 @@ dependencies:
   - fastparquet
   - h3-py >=4.1
   - pandas
-  - rasterio >=1.3
+  - rasterio >=1.4.2
 
 # documentation dependencies (optional)
   - ipykernel

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,4 +1,4 @@
 fastparquet
 h3 >=4.1
 pandas
-rasterio >=1.3
+rasterio >=1.4.2


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces the `rasterio >=1.4.2` minimum pin to ensure compatibility with the forthcoming [gdal](https://github.com/OSGeo/gdal) 3.10.0 release.

See the [rasterio 1.4.2 release notes](https://github.com/rasterio/rasterio/releases/tag/1.4.2).

---
