### PR TITLE
ruff: drop use of .ruff.toml

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,8 +1,0 @@
-extend = "pyproject.toml"
-
-[lint.extend-per-file-ignores]
-"src/geovista/geoplotter.py" = [
-  # flake8-annotations (ANN)
-  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
-  "ANN401", # Dynamically typed expressions (typing.Any).
-]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,6 @@ exclude .all-contributorsrc
 exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yml
-exclude .ruff.toml
 include *.md
 exclude CHANGELOG.rst
 include CITATION.cff

--- a/changelog/1217.contributor.rst
+++ b/changelog/1217.contributor.rst
@@ -1,0 +1,4 @@
+Dropped the use of ``.ruff.toml`` to capture outstanding
+`ruff <https://github.com/astral-sh/ruff>`__ rule exceptions. Non-compliances
+have been addressed or moved to the ``pyproject.toml``.
+(:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,6 @@ preview = false
 # Allow information-source (U+2139) which could be confused for "i".
 allowed-confusables = ["ℹ"]
 ignore = [
-  # NOTE: Non-permanent exclusions should be added to ".ruff.toml".
-
   # flake8-annotations (ANN)
   # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
   "ANN101", # Missing type annotation for 'self' in method.
@@ -263,6 +261,11 @@ max-statements = 91
 "src/geovista/examples/spatial_index/uber_h3.py" = [
   # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
   "FBT001", # flake8-boolean-trap: Boolean-typed positional argument in function definition.
+]
+# TODO @bjlittle: resolve use of typing.Any
+"src/geovista/geoplotter.py" = [
+  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+  "ANN401", # flake8-annotations: Dynamically typed expressions (typing.Any).
 ]
 "test_*.py" = [
   # flake8-annotations (ANN)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request drops the use of the `.ruff.toml` to capture temporary non-compliances.

All non-compliances have been addressed or relocated with `TODO` markers to the `pyproject.toml`.

---
