### PR TITLE
docs: resolve unnecessary linkcheck redirects

### DIFF
--- a/changelog/1226.documentation.rst
+++ b/changelog/1226.documentation.rst
@@ -1,0 +1,1 @@
+Resolved unnecessary ``linkcheck`` URL redirects. (:user:`bjlittle`)

--- a/docs/src/overview.rst
+++ b/docs/src/overview.rst
@@ -74,7 +74,7 @@ PyVista in a Nutshell
 
 .. figure:: _static/images/pyvista-examples.png
     :figclass: margin
-    :target: https://docs.pyvista.org/version/stable/examples/
+    :target: https://docs.pyvista.org/examples/
     :name: pyvista-figure
     :alt: PyVista Examples
 
@@ -110,6 +110,6 @@ Thanks for your patience 🙏
     Page link URL resources in alphabetical order:
 
 .. _Jupyter: https://jupyter.org/
-.. _Mesh data structures: https://docs.pyvista.org/version/stable/examples/index.html#mesh-creation
+.. _Mesh data structures: https://docs.pyvista.org/examples/index.html#mesh-creation
 .. _ParaView: https://www.paraview.org/
-.. _filtering algorithms: https://docs.pyvista.org/version/stable/examples/index.html#filtering
+.. _filtering algorithms: https://docs.pyvista.org/examples/index.html#filtering

--- a/docs/src/quick_start.rst
+++ b/docs/src/quick_start.rst
@@ -350,4 +350,4 @@ If so, then let's explore the :ref:`next steps <gv-next-steps>` on your
 .. _Plymouth Sound and Tamar River: https://www.google.com/maps/place/Plymouth+Sound/@50.3337382,-4.2215988,12z/data=!4m5!3m4!1s0x486c93516bbce307:0xded7654eaf4f8f83!8m2!3d50.3638359!4d-4.1441365
 .. _Robinson: https://proj4.org/en/stable/operations/projections/robin.html
 .. _WAVEWATCH III: https://github.com/NOAA-EMC/WW3
-.. _threshold: https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.threshold.html#pyvista.DataSetFilters.threshold
+.. _threshold: https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.threshold

--- a/docs/src/reference/bindings.rst
+++ b/docs/src/reference/bindings.rst
@@ -150,5 +150,5 @@ Primary keyboard and mouse bindings that control the rendered scene.
     Page link URL resources in alphabetical order:
 
 
-.. _isometric camera: https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_isometric.html
-.. _pyvista keyboard bindings: https://docs.pyvista.org/version/stable/api/plotting/plotting.html#plotting
+.. _isometric camera: https://docs.pyvista.org/api/plotting/_autosummary/pyvista.plotter.view_isometric
+.. _pyvista keyboard bindings: https://docs.pyvista.org/api/plotting/plotting.html#plotting

--- a/docs/src/reference/environment.rst
+++ b/docs/src/reference/environment.rst
@@ -122,5 +122,5 @@ Notable third-party environment variables that influence the behaviour of
 .. _SPEC 1: https://scientific-python.org/specs/spec-0001/
 .. _XDG Base Directory Specification: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 .. _lazy-loader: https://github.com/scientific-python/lazy-loader
-.. _GitHub Action: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+.. _GitHub Action: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
 .. _Read the Docs: https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS

--- a/docs/src/reference/glossary.rst
+++ b/docs/src/reference/glossary.rst
@@ -91,9 +91,9 @@ Say what you mean. Mean what you say.
     Page link URL resources in alphabetical order:
 
 
-.. _PyVista threshold: https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.threshold.html#pyvista.DataSetFilters.threshold
-.. _PyVista warp_by_scalar: https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.warp_by_scalar.html#pyvista.DataSetFilters.warp_by_scalar
-.. _What is a Cell?: https://docs.pyvista.org/version/stable/user-guide/what-is-a-mesh.html#what-is-a-cell
-.. _What is a Point?: https://docs.pyvista.org/version/stable/user-guide/what-is-a-mesh.html#what-is-a-point
-.. _What is a Mesh?: https://docs.pyvista.org/version/stable/user-guide/what-is-a-mesh.html#what-is-a-mesh
+.. _PyVista threshold: https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.threshold
+.. _PyVista warp_by_scalar: https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.warp_by_scalar
+.. _What is a Cell?: https://docs.pyvista.org/user-guide/what-is-a-mesh.html#what-is-a-cell
+.. _What is a Point?: https://docs.pyvista.org/user-guide/what-is-a-mesh.html#what-is-a-point
+.. _What is a Mesh?: https://docs.pyvista.org/user-guide/what-is-a-mesh.html#what-is-a-mesh
 .. _vtkActor: https://vtk.org/doc/nightly/html/classvtkActor.html#details

--- a/src/geovista/examples/scalar_data/from_tiff__dem.py
+++ b/src/geovista/examples/scalar_data/from_tiff__dem.py
@@ -10,8 +10,8 @@ GeoTIFF DEM
 -----------
 
 This example demonstrates how to render **Digital Elevation Model** (DEM) data
-encoded in an `OGC GeoTIFF <https://www.ogc.org/standard/geotiff/>`_ as a
-geolocated mesh.
+encoded in an `OGC GeoTIFF <https://www.ogc.org/publications/standard/geotiff/>`_
+as a geolocated mesh.
 
 📋 Summary
 ^^^^^^^^^^

--- a/src/geovista/examples/scalar_data/from_tiff__rgb.py
+++ b/src/geovista/examples/scalar_data/from_tiff__rgb.py
@@ -9,7 +9,7 @@ GeoTIFF RGB
 -----------
 
 This example demonstrates how to render an
-`OGC GeoTIFF <https://www.ogc.org/standard/geotiff/>`_ RGB image as a
+`OGC GeoTIFF <https://www.ogc.org/publications/standard/geotiff/>`_ RGB image as a
 geolocated mesh.
 
 📋 Summary

--- a/src/geovista/examples/warp/from_unstructured__fvcom.py
+++ b/src/geovista/examples/warp/from_unstructured__fvcom.py
@@ -30,7 +30,7 @@ Cornwall, UK.
 
 The warp uses :meth:`~pyvista.PolyDataFilters.compute_normals` and
 :meth:`~pyvista.DataSetFilters.warp_by_scalar`. See
-`Computing Surface Normals <https://docs.pyvista.org/version/stable/examples/01-filter/compute-normals.htm>`_
+`Computing Surface Normals <https://docs.pyvista.org/examples/01-filter/compute-normals>`_
 for further details.
 
 .. tags::

--- a/src/geovista/examples/warp/from_unstructured__lfric_orog.py
+++ b/src/geovista/examples/warp/from_unstructured__lfric_orog.py
@@ -28,7 +28,7 @@ values, to highlight the global surface topography.
 
 The warp uses :meth:`~pyvista.PolyDataFilters.compute_normals` and
 :meth:`~pyvista.DataSetFilters.warp_by_scalar`. See
-`Computing Surface Normals <https://docs.pyvista.org/version/stable/examples/01-filter/compute-normals.htm>`_
+`Computing Surface Normals <https://docs.pyvista.org/examples/01-filter/compute-normals>`_
 for further details.
 
 .. tags::

--- a/src/geovista/examples/warp/from_unstructured__lfric_orog_eqc.py
+++ b/src/geovista/examples/warp/from_unstructured__lfric_orog_eqc.py
@@ -33,7 +33,7 @@ values, to highlight the global surface topography.
 
 The warp uses :meth:`~pyvista.PolyDataFilters.compute_normals` and
 :meth:`~pyvista.DataSetFilters.warp_by_scalar`. See
-`Computing Surface Normals <https://docs.pyvista.org/version/stable/examples/01-filter/compute-normals.htm>`_
+`Computing Surface Normals <https://docs.pyvista.org/examples/01-filter/compute-normals>`_
 for further details.
 
 .. tags::


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request addresses the fixable documentation `linkcheck` redirects to their permanent URLs.

Note that, after performing a `make linkcheck` simply check the `sphinx` auto-generated `_build/linkcheck/output.txt`.

The remaining redirects are attributed to the URLs generated by `sphinx` when creating references into the `pyvista` API. 

---
