### PR TITLE
pin gha ubuntu base image

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -27,7 +27,6 @@ concurrency:
 jobs:
   tests:
     name: "${{ matrix.session }} (${{ matrix.version }})"
-
     runs-on: ${{ matrix.os }}
 
     defaults:
@@ -41,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-22.04"]
         version: ["py312"]
         session: ["doctest", "linkcheck"]
 

--- a/.github/workflows/ci-tests-lock.yml
+++ b/.github/workflows/ci-tests-lock.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   test-lock:
     name: "test lock (${{ matrix.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     env:
       ENV_NAME: "ci-tests-lock"
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-22.04"]
         version: ["py312"]
 
     steps:

--- a/.github/workflows/ci-tests-pypi.yml
+++ b/.github/workflows/ci-tests-pypi.yml
@@ -33,11 +33,12 @@ env:
 jobs:
   test-pypi:
     name: "test pypi (py${{ matrix.version }})"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: ["ubuntu-22.04"]
         version: ["3.12"]
 
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,6 @@ defaults:
 jobs:
   tests:
     name: "${{ matrix.session }} ${{ matrix.marker }} (${{ matrix.version }})"
-
     runs-on: ${{ matrix.os }}
 
     env:
@@ -43,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-22.04"]
         version: ["py311", "py312"]
         session: ["tests"]
         marker: ["image", "not image"]

--- a/changelog/1241.contributor.rst
+++ b/changelog/1241.contributor.rst
@@ -1,0 +1,3 @@
+Dropped use of ``latest`` tag and explicitly pinned to ``ubuntu-22.04``
+:fab:`github` Action `runner-image <https://github.com/actions/runner-images>`__.
+(:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The default GHA runner `latest` base image for `ubuntu` has bumped from 22.04 to 24.04.

This causes issues as the `libgl1-mesa-glx` APT package is not available and is the source of image tests hanging and/or the GHA `cache-apt-pkgs-action` to fail.

Adopting best practice advice from the `pyvista` core developers to pin the base image version and watch the GHA `runner-images` announcements to migrate (bump base image version) as part of a controlled, rather than unexpected changes through the `latest` base image label.  

Note that, using an explicit GHA base image version is akin to the explicit `os` version used within the `.readthedocs.yml`.

Reference [actions/runner-images](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20241211.1)

---
