### PR TITLE
docs: enable sphinx-duration extension

### DIFF
--- a/changelog/1242.dependency.rst
+++ b/changelog/1242.dependency.rst
@@ -1,0 +1,2 @@
+Enabled ``sphinx.ext.duration`` to assist with identifying documentation building
+bottlenecks. (:user:`bjlittle`)

--- a/changelog/989.internal.rst
+++ b/changelog/989.internal.rst
@@ -1,1 +1,3 @@
-Added `adRise/update-pr-branch <https://github.com/adRise/update-pr-branch>`__ GHA to automatically update stale ``auto-merge`` pull-requests. (:user:`tkoyama010`)
+Added `adRise/update-pr-branch <https://github.com/adRise/update-pr-branch>`__
+:fab:`github` Action to automatically update stale ``auto-merge`` pull-requests.
+(:user:`tkoyama010`)

--- a/changelog/996.internal.rst
+++ b/changelog/996.internal.rst
@@ -1,1 +1,2 @@
-Enabled ``require_passed_checks`` for `adRise/update-pr-branch <https://github.com/adRise/update-pr-branch>`__ GHA. (:user:`bjlittle`)
+Enabled ``require_passed_checks`` for `adRise/update-pr-branch <https://github.com/adRise/update-pr-branch>`__
+:fab:`github` Action. (:user:`bjlittle`)

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -109,6 +109,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "autoapi.extension",
     "sphinx.ext.doctest",
+    "sphinx.ext.duration",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enables the [sphinx-duration](https://www.sphinx-doc.org/en/master/usage/extensions/duration.html) extension for measuring `sphinx` processing times which may assist with identifying documentation build bottlenecks.

---
