### PR TITLE
gha: update label

### DIFF
--- a/.github/workflows/ci-label.yml
+++ b/.github/workflows/ci-label.yml
@@ -65,10 +65,10 @@ jobs:
           labels: 'type: examples'
 
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'nep') || startsWith(github.event.pull_request.head.ref, 'nep29')
+        if: startsWith(github.event.pull_request.head.ref, 'spec') || startsWith(github.event.pull_request.head.ref, 'spec0')
         with:
           github_token: ${{ github.token }}
-          labels: 'type: nep-29'
+          labels: 'type: spec-0'
 
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'perf') || startsWith(github.event.pull_request.head.ref, 'performance')

--- a/changelog/1254.contributor.rst
+++ b/changelog/1254.contributor.rst
@@ -1,0 +1,2 @@
+Updated the ``ci-label`` :fab:`github` Action to migrate from ``nep-29`` to
+``spec-0``. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request updates the `ci-label` GHA to migrate from `nep-29` to `spec-0`.

---
