### PR TITLE
fix from_cartesian polar cell unfold

### DIFF
--- a/changelog/1301.bugfix.rst
+++ b/changelog/1301.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed :func:`geovista.common.from_cartesian` to handle polar points with
+no associated cell. (:user:`bjlittle`)

--- a/tests/common/test_from_cartesian.py
+++ b/tests/common/test_from_cartesian.py
@@ -22,6 +22,7 @@ from geovista.common import (
     to_cartesian,
     wrap,
 )
+from geovista.pantry.meshes import lfric_orog
 
 
 def test_defaults(lam_uk_sample, lam_uk):
@@ -125,3 +126,11 @@ def test_lines_closed_interval(closed_interval, lonlat, pids):
     mesh.lines = lines
     result = from_cartesian(mesh, closed_interval=closed_interval)
     assert np.all(np.isclose(result[:, :-1], lonlat)) == closed_interval
+
+
+def test_convert_edges_pole_cell_unfold():
+    """Test edges with no polar cell associated with polar point."""
+    mesh = lfric_orog()
+    _, edges = mesh.contour_banded(3)
+    result = from_cartesian(edges)
+    assert result.shape == (edges.n_points, 3)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request fixes an issue within `geovista.common.from_cartesian` which attempts to identify and unfold the cells associated with mesh points on the poles.

There can be the case where there is no cell associated with a polar point, which this PR resolves. 

The use case that exposed this situation was when using the `contour_banded` filter and then transforming the resultant `edges` of the associated `contours`.

---
