### PR TITLE
created `sample` sphinx-tags group

### DIFF
--- a/changelog/1306.documentation.rst
+++ b/changelog/1306.documentation.rst
@@ -1,0 +1,2 @@
+Added the new ``sample`` `sphinx-tags <https://github.com/melissawm/sphinx-tags>`__ category.
+(:user:`bjlittle`)

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -257,7 +257,8 @@ tags_badge_colors = {
     "filter:*": "success",  # extrude, threshold, warp
     "load:*": "dark",  # rectilinear, curvilinear, unstructured, points, geotiff
     "projection:*": "warning",  # crs, transform
-    "render": "danger",  # camera
+    "render:*": "danger",  # camera
+    "sample:*": "dark",  # rectilinear, curvilinear, unstructured, points, geotiff
     "style:*": "light",  # colormap, lighting, opacity, shading
     "widget:*": "info",  # checkbox, logo
 }


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The `sample` category is akin to `load` but is a tag for examples that use the sample data available from `geovista.pantry.meshes`.

Whereas the `load` group is appropriate for examples that use the `geovista.bridge` to load from `geovista.pantry.data`.

As a convenience, the assets available in `geovista.pantry.meshes` are created from `geovista.pantry.data`.

This clarification with shortly be captured in the `Developer` -> `Contributing` section of the documentation.

---
