### PR TITLE
rename region extraction gallery examples section

### DIFF
--- a/changelog/1307.documentation.rst
+++ b/changelog/1307.documentation.rst
@@ -1,0 +1,3 @@
+Renamed the gallery examples ``Region Extraction`` section to ``Extraction`` to
+maintain the primary sidebar menu in alphabetical order.
+(:user:`bjlittle`)

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -10,3 +10,4 @@ pooch
 pykdtree
 pyproj >=3.3
 pyvista >=0.43.1
+shapely <2.0.7

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -10,4 +10,3 @@ pooch
 pykdtree
 pyproj >=3.3
 pyvista >=0.43.1
-shapely <2.0.7

--- a/src/geovista/examples/extraction/README.rst
+++ b/src/geovista/examples/extraction/README.rst
@@ -3,4 +3,4 @@
 Extraction
 ==========
 
-Examples highlighting the various region manifold extraction techniques available.
+Highlights various region :term:`manifold` extraction techniques available.

--- a/src/geovista/examples/extraction/README.rst
+++ b/src/geovista/examples/extraction/README.rst
@@ -1,4 +1,6 @@
 .. _gv-examples-extraction:
 
-Region Extraction
-=================
+Extraction
+==========
+
+Examples highlighting the various region manifold extraction techniques available.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request performs a minor rebrand of the `Gallery` -> `Examples` -> `Region Extraction` section to be simply `Extraction` to keep the sidebar menu in alphabetical order.

The pull-request additionally adds a pithy one liner summary for the section to compensate on dropping the `Region` clarification.

The reason for the rebrand is simply that `sphinx-gallery` by default orders sections by the associated folder name. Explicit control can by assumed by using the `sphinx-gallery` [subsection_order](https://sphinx-gallery.github.io/stable/configuration.html#sorting-gallery-subsections) configuration option but this would introduce a maintenance overhead to contributors.

From this:
![image](https://github.com/user-attachments/assets/cceb22ea-d804-4e7b-8891-8fce9e3df32d)

To this:
![image](https://github.com/user-attachments/assets/238fa658-f754-4274-9244-8bc35641052d)



---
