### PR TITLE
configure setup-miniconda with conda-remove-defaults

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -69,6 +69,7 @@ jobs:
         miniforge-version: latest
         activate-environment: ${{ env.ENV_NAME }}
         use-only-tar-bz2: false
+        conda-remove-defaults: true
 
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -63,6 +63,7 @@ jobs:
         miniforge-version: latest
         activate-environment: ${{ env.ENV_NAME }}
         use-only-tar-bz2: false
+        conda-remove-defaults: true
 
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache

--- a/.github/workflows/ci-tests-lock.yml
+++ b/.github/workflows/ci-tests-lock.yml
@@ -71,6 +71,7 @@ jobs:
         activate-environment: ${{ env.ENV_NAME }}
         environment-file: requirements/conda-linux-64.lock
         use-only-tar-bz2: false
+        conda-remove-defaults: true
 
     - name: "conda info"
       run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,6 +76,7 @@ jobs:
         miniforge-version: latest
         activate-environment: ${{ env.ENV_NAME }}
         use-only-tar-bz2: false
+        conda-remove-defaults: true
 
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -104,6 +104,7 @@ jobs:
         miniforge-version: latest
         activate-environment: ${{ env.ENV_NAME }}
         use-only-tar-bz2: false
+        conda-remove-defaults: true
 
     - name: "conda environment cache"
       uses: ./.github/workflows/composite/conda-env-cache

--- a/changelog/1324.contributor.rst
+++ b/changelog/1324.contributor.rst
@@ -1,0 +1,3 @@
+Configured the ``conda-remove-defaults = true`` option for the
+`setup-miniconda <https://github.com/conda-incubator/setup-miniconda>`__
+:fab:`github` Action. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request configures the `conda-remove-defaults: true` option for the `setup-miniconda` GHA.

This removes the GHA Summary Annotaion warning diagnostic message e.g., 

![image](https://github.com/user-attachments/assets/e59bd5aa-a26c-4403-a553-883de7836304)

---
