### PR TITLE
pypi-publish GHA use kebab-case options

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -166,9 +166,9 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
-        print_hash: true
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        print-hash: true
 
 
   publish-artifacts-pypi:
@@ -188,4 +188,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        print_hash: true
+        print-hash: true

--- a/changelog/1325.contributor.rst
+++ b/changelog/1325.contributor.rst
@@ -1,0 +1,3 @@
+Converted `pypi-publish <https://github.com/pypa/gh-action-pypi-publish>`__
+:fab:`github` Action options from ``snake_case`` to ``kebab-case``.
+(:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request updates the `pypi-publish` GHA options to use `kebab-case` instead of the deprecated `snake_case`. 

Both forms are valid, but `snake_case` support make be removed in v3.

---
