### PR TITLE
cli: tidy --cache and --version options

### DIFF
--- a/src/geovista/cli.py
+++ b/src/geovista/cli.py
@@ -189,14 +189,12 @@ def _plural(quantity: int) -> str:
 def main(version: bool, report: bool, cache: bool) -> None:  # numpydoc ignore=PR01
     """To get help for geovista commands, simply use "geovista COMMAND --help"."""
     if version:
-        click.echo("version ", nl=False)
         click.secho(f"{__version__}", fg=FG_COLOUR)
 
     if report:
         click.echo(Report())
 
     if cache:
-        click.echo("cache directory ", nl=False)
         click.secho(f"{CACHE.abspath}", fg=FG_COLOUR)
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request removed convenience text to the `geovista --cache` and `geovista --version` output.

This is to allow the output to be directly used by third-parties e.g., on Linux 
```shell
> cd $(geovista --cache)
> export GV_VERSION=$(geovista --version)
```

---
