### PR TITLE
enable sphinx parallel build

### DIFF
--- a/changelog/1391.documentation.rst
+++ b/changelog/1391.documentation.rst
@@ -1,0 +1,2 @@
+Enabled ``sphinx-build`` optimisation to distribute its workload automatically
+across the number of available CPUs. (:user:`bjlittle`)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,9 +6,7 @@ export PYDEVD_DISABLE_FILE_VALIDATION := 1
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-#
-# -W  Warnings promoted to errors
-SPHINXOPTS    ?= --fail-on-warning --keep-going
+SPHINXOPTS    ?= --fail-on-warning --keep-going --jobs auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = src
 BUILDDIR      = _build


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enables `sphinx-build` to distribute its workload automatically across the number of CPUs available, see [here](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j).

The parallel building behaviour appears to be stable and gives between ~20-30% speed-up (locally) ... TBH any optimisation here is a win.

---
