### PR TITLE
setuptools pep639 license and license-files

### DIFF
--- a/changelog/1428.dependency.rst
+++ b/changelog/1428.dependency.rst
@@ -1,0 +1,3 @@
+Introduced minimum pin ``setuptools>=77.0.3`` to support
+`PEP 639 <https://peps.python.org/pep-0639/>`__ changes to ``license`` and
+``license-files`` fields in the ``pyproject.toml``. (:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Defined by PEP 518
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77.0.3", "setuptools_scm>=8"]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"
 
@@ -10,7 +10,6 @@ authors = [{ name = "GeoVista Contributors", email = "geovista.pub@gmail.com" }]
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
@@ -33,7 +32,8 @@ keywords = [
   "unstructured",
   "vtk",
 ]
-license.file = "LICENSE"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "geovista"
 requires-python = ">=3.11"
 
@@ -298,7 +298,6 @@ convention = "numpy"
 
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 zip-safe = false
 
 

--- a/requirements/geovista.yml
+++ b/requirements/geovista.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 
 # setup dependencies (core)
-  - setuptools >=64
+  - setuptools >=77.0.3
   - setuptools-scm >=8
 
 # core dependencies
@@ -20,7 +20,8 @@ dependencies:
   - pooch
   - pykdtree
   - pyproj >=3.3
-  - pyvista >=0.43.1
+  - pyvista >=0.43.1,<0.44.3
+  - vtk <9.4
 
 # pantry dependencies (core)
   - netcdf4

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -10,3 +10,4 @@ pooch <1.8.3
 pykdtree <1.4.2
 pyproj >=3.3,<3.7.2
 pyvista >=0.43.1,<0.44.3
+vtk <9.4


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request updates the `pyproject.toml` for `setuptools` [PEP639](https://peps.python.org/pep-0639/) support for `license` and `license-files`. Also see [here](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

As such, it introduces the minimum pin `setuptools>=77.0.3`.

---
