### PR TITLE
Fix tests on newly Windows machine

### DIFF
--- a/changelog/1436.bugfix.rst
+++ b/changelog/1436.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :mod:`geovista.cache` tests for ``Windows`` platform. (:user:`beroda`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ addopts = [
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS NUMBER"
 filterwarnings = [
   "error",
+  "ignore::cartopy.io.DownloadWarning",
   "ignore:geovista unable to remesh 1 cell:UserWarning",
   "ignore:numpy.ndarray size changed:RuntimeWarning",
   "ignore:pyvista test cache image dir:UserWarning",

--- a/tests/cache/test_CACHE.py
+++ b/tests/cache/test_CACHE.py
@@ -19,7 +19,7 @@ def test_fetch():
     asset = Path("pantry/data/lams/london.nc.bz2")
     asset_cache = CACHE.abspath / asset
     asset_cache.unlink(missing_ok=True)
-    actual = CACHE.fetch(str(asset))
+    actual = CACHE.fetch(asset.as_posix())
     assert asset.name == Path(actual).name
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
While implementing integration tests using tox in https://github.com/pyvista/pyvista/pull/7441, I installed locally `geovista` on my Windows machine without any prior installation from PyPi or conda (ie. no cache downloads).

Some tests were failing in local. This PR fixes them.

---
