### PR TITLE
gha: ci-locks pr generation only on diff

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: "create pull-request"
         id: cpr
+        if: ${{ hashFiles('diff.md') }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Protect the PR generation within `ci-locks` with a check to ensure that there is a package dependency delta as resolved by `pixi`.

---
