### PR TITLE
revert trame-vtk

### DIFF
--- a/changelog/1561.dependency.rst
+++ b/changelog/1561.dependency.rst
@@ -1,0 +1,2 @@
+Introduced pin ``trame-vtk ==2.8.15`` to avoid subplot interactive scene
+behaviour regression. (:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -511,7 +511,7 @@ towncrier = ">=24.8.0,<25"
 trame = "==3.10.2"
 trame-client = ">=3.9.0,<4"
 trame-server = ">=3.4.0,<4"
-trame-vtk = "==2.9.0"
+trame-vtk = "==2.8.15"
 trame-vuetify = "==3.0.1"
 
 [tool.pixi.feature.docs.pypi-dependencies]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

After some investigation the source of a regression in the behaviour of subplot interactive scenes is due to the recently released `trame-vtk` 2.9.0.

----

<img width="446" height="392" alt="image" src="https://github.com/user-attachments/assets/5e492182-52ec-4942-b621-b58de0083d1b" />

----

The last working version was the previously pinned version 2.8.15

Reference #1552 and subsequent #1553.

See this docs build of the [Panel Extraction](https://geovista--1553.org.readthedocs.build/en/1553/generated/gallery/extraction/panel_manifold.html#sphx-glr-generated-gallery-extraction-panel-manifold-py) Interactive Scene example to explore this regression.

---
