### PR TITLE
pixi: test and test-clean tasks for test feature

### DIFF
--- a/changelog/1578.contributor.rst
+++ b/changelog/1578.contributor.rst
@@ -1,3 +1,3 @@
-Added the `pixi <https://github.com/prefix-dev/pixi>`__ 🧚 tasks
+Added the `pixi <https://github.com/prefix-dev/pixi>`__ 🧚 workflow tasks
 ``clean-all``, ``clean-cache`` and ``doctest`` for the ``docs``
 feature. (:user:`bjlittle`)

--- a/changelog/1585.contributor.rst
+++ b/changelog/1585.contributor.rst
@@ -1,0 +1,2 @@
+Added the `pixi <https://github.com/prefix-dev/pixi>`__ 🧚 workflow tasks
+``test`` and ``test-clean`` for the ``test`` feature. (:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -568,3 +568,11 @@ pytest-cov = ">=6.1.1,<7"
 pytest-mock = ">=3.14.1,<4"
 pytest-pretty = ">=1.3.0,<2"
 pytest-pyvista = ">=0.2.0,<0.3"
+
+[tool.pixi.feature.test.tasks.test-clean]
+cmd = "rm -rf tests/plotting/image_cache test_images"
+
+[tool.pixi.feature.test.tasks.test]
+args = [{ "arg" = "option", "default" = "" }]
+cmd = "pytest {% if option | length %}-m '{{ option }}' {% endif %}--generated_image_dir test_images"
+depends-on = [{ "task" = "test-clean" }]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds a `pixi` task workflow to run `pytest` for the `test` feature.

Supports the following:

| Command                       | Description |
| ----------------------------- | ----------- |
| `pixi run test`             | Run all tests. |
| `pixi run test image`       | Run only `image` marker visual tests. |
| `pixi run test example`     | Run only `example` marker visual tests. |
| `pixi run test not image`   | Run non-`image` marker tests. |
| `pixi run test not example` | Run non-`example` marker tests. |
| `pixi run test-clean`       | Clean visual test caches. |

Note that the `test-clean` task is always executed prior to any `test` task.

All visual tests are captured in the `test_images` root directory, which is cleaned out automatically prior to commencing a test run.

---
