### PR TITLE
docs: auto detect and skip rtd PR build when noop

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,8 +11,8 @@ build:
     post_checkout:
       # require full history for correct setuptools-scm version discovery
       - |
-        git fetch --unshallow
-        git fetch --all
+        git fetch --unshallow;
+        git fetch --all;
         #
         # https://docs.readthedocs.com/platform/stable/build-customization.html#cancel-build-based-on-a-condition
         # https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS_VERSION_TYPE
@@ -28,8 +28,8 @@ build:
       - git stash
     post_install:
       - |
-        git stash pop
-        geovista download --operational --decompress
+        git stash pop;
+        geovista download --operational --decompress;
 
 conda:
   environment: requirements/locks/rtd.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,15 +10,26 @@ build:
   jobs:
     post_checkout:
       # require full history for correct setuptools-scm version discovery
-      - git fetch --unshallow
-      - git fetch --all
+      - |
+        git fetch --unshallow
+        git fetch --all
+        #
+        # https://docs.readthedocs.com/platform/stable/build-customization.html#cancel-build-based-on-a-condition
+        # https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS_VERSION_TYPE
+        #
+        if [ "${READTHEDOCS_VERSION_TYPE}" = "external" ] && git diff --quiet origin/main -- .all-contributorsrc .readthedocs.yml CHANGELOG.rst pixi.lock pyproject.toml changelog/ requirements/;
+        then
+          # (sum(list("skip".encode("ascii"))) % 256) == 183
+          exit 183;
+        fi
     pre_install:
       # keep checkout untainted from RTD to ensure correct
       # setuptools-scm version
       - git stash
     post_install:
-      - git stash pop
-      - geovista download --operational --decompress
+      - |
+        git stash pop
+        geovista download --operational --decompress
 
 conda:
   environment: requirements/locks/rtd.yml

--- a/changelog/1592.contributor.rst
+++ b/changelog/1592.contributor.rst
@@ -1,0 +1,3 @@
+Optimised the :fab:`github` pull-request workflow by auto-detecting whether to
+skip or build ``readthedocs`` documentation based on the file/s changed
+within the specific pull-request. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request streamlines the pull-request workflow by only building the documentation on RTD when necessary.

This is achieved by detecting whether there are any specific files within the pull-request that will require a documentation re-build due to content, infrastructure or dependencies changes i.e.,

- `.all-contributorsrc` - content
- `.readthedocs.yml` - infrastructure
- `CHANGELOG.rst` - content
- `pixi.lock` - dependencies
- `pyproject.toml` - infrastructure & dependencies
- `changelog/` - content
- `requirements/` - dependencies

Note that this optimisation only applies to pull-request builds.

---
