### PR TITLE
docs: build rtd with default doctree

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,7 +26,7 @@ build:
       - pixi run --frozen --environment docs geovista download --operational --decompress
     build:
       html:
-        - pixi run --frozen --environment docs sphinx-build -T -b html -d _build/doctrees docs/src $READTHEDOCS_OUTPUT/html
+        - pixi run --frozen --environment docs sphinx-build -T -b html docs/src $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: docs/src/conf.py


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Healing a self-inflected wound from #1595 ... whereby docstring and inline interactive visualisations are not loaded and rendered.

The `plot-directive` (part of `pyvista`) defaults to the `Path(setup.app.doctreedir).parent`, therefore the base directory of the `doctree` is significant and relevant here. Clearly using `-d _build/doctrees` is the root of the issue.

The `doctree` base directory requires to be visible (publishable), so opting to use the default `sphinx-build` directory which uses the output directory as a base. 

---
