### PR TITLE
ignore direnv `.envrc` configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/

--- a/changelog/1609.contributor.rst
+++ b/changelog/1609.contributor.rst
@@ -1,0 +1,2 @@
+Added the `direnv <https://github.com/direnv/direnv>`__ ``.envrc`` configuration
+file to ``.gitignore``. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request acknowledges that developers may want to use [direnv](https://github.com/direnv/direnv) e.g., [auto-enable](https://pixi.sh/latest/integration/third_party/direnv/) a `pixi` environment.

---
