### PR TITLE
docs: change sidebar github icons

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -498,12 +498,12 @@ html_theme_options = {
         {
             "name": "GitHub Issues",
             "url": "https://github.com/bjlittle/geovista/issues",
-            "icon": "fa-brands fa-square-github fa-fw",
+            "icon": "far fa-circle-dot fa-fw",
         },
         {
-            "name": "GitHub Pulls",
+            "name": "GitHub PRs",
             "url": "https://github.com/bjlittle/geovista/pulls",
-            "icon": "fa-brands fa-github-alt fa-fw",
+            "icon": "fa fa-code-pull-request fa-fw",
         },
         {
             "name": "Bluesky",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Rebrand the RTD sidebar GH font awesome icons from

<img width="121" height="22" alt="image" src="https://github.com/user-attachments/assets/b039b7cd-922c-4ec5-be16-2c6e662ed988" />


to

<img width="128" height="26" alt="image" src="https://github.com/user-attachments/assets/d39c1017-bad3-42b2-8f2f-c84af24ae40c" />


---
