### PR TITLE
adopt ruff cpy preview rule

### DIFF
--- a/changelog/1668.contributor.rst
+++ b/changelog/1668.contributor.rst
@@ -1,0 +1,3 @@
+Enabled `ruff <https://github.com/astral-sh/ruff>`__ ``flake8-copyright``
+preview rule (``CPY001``) to enforce file copyright preamble.
+(:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ preview = false
 [tool.ruff.lint]
 # Allow information-source (U+2139) which could be confused for "i".
 allowed-confusables = ["ℹ"]
+explicit-preview-rules = true
+extend-select = ["CPY001"]
 ignore = [
   # flake8-commas (COM)
   # https://docs.astral.sh/ruff/rules/#flake8-commas-com
@@ -213,7 +215,7 @@ ignore = [
   # https://docs.astral.sh/ruff/rules/#flake8-todos-td
   "TD003", # Missing issue link on the line following this TODO.
 ]
-preview = false
+preview = true
 select = [
   "ALL",
 
@@ -222,6 +224,14 @@ select = [
   "D212", # Multi-line docstring summary should start at the first line
 ]
 
+
+[tool.ruff.lint.flake8-copyright]
+notice-rgx = '''
+# Copyright \(c\) 2021, GeoVista Contributors\.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license\.
+# See the LICENSE file in the package root directory for licensing details\.
+'''
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
@@ -255,6 +265,11 @@ max-statements = 91
   # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
   "ANN001", # Missing type annotation for function argument.
   "ANN201", # Missing return type annotation for public function.
+]
+"docs/src/tutorials/region-manifold-extraction.ipynb" = [
+  # flake8-copyright (CPY)
+  # https://docs.astral.sh/ruff/rules/#flake8-copyright-cpy
+  "CPY001", # Missing copyright notice at top of file.
 ]
 "src/geovista/cli.py" = [
   # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt

--- a/src/geovista/__init__.py
+++ b/src/geovista/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021, GeoVista Contributors.
+# Copyright (c) 2021, GeoVista Contributors.
 #
 # This file is part of GeoVista and is distributed under the 3-Clause BSD license.
 # See the LICENSE file in the package root directory for licensing details.

--- a/src/geovista/__init__.pyi
+++ b/src/geovista/__init__.pyi
@@ -1,3 +1,8 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
 # see https://scientific-python.org/specs/spec-0001/#type-checkers
 from .bridge import Transform
 from .geoplotter import GeoPlotter

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -221,7 +221,7 @@ class StrEnumPlus(StrEnum):
         .. versionadded:: 0.3.0
 
         """
-        return tuple([member.value for member in cls])
+        return tuple(member.value for member in cls)
 
 
 class Preference(StrEnumPlus):

--- a/src/geovista/pantry/__init__.py
+++ b/src/geovista/pantry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, GeoVista Contributors.
+# Copyright (c) 2021, GeoVista Contributors.
 #
 # This file is part of GeoVista and is distributed under the 3-Clause BSD license.
 # See the LICENSE file in the package root directory for licensing details.

--- a/src/geovista/pantry/textures.py
+++ b/src/geovista/pantry/textures.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, GeoVista Contributors.
+# Copyright (c) 2021, GeoVista Contributors.
 #
 # This file is part of GeoVista and is distributed under the 3-Clause BSD license.
 # See the LICENSE file in the package root directory for licensing details.

--- a/tests/common/test_Preference.py
+++ b/tests/common/test_Preference.py
@@ -21,12 +21,12 @@ def test_member_count():
 
 def test_members():
     """Test expected enumeration members."""
-    assert tuple([member.value for member in Preference]) == EXPECTED_VALUES
+    assert tuple(member.value for member in Preference) == EXPECTED_VALUES
 
 
 def test_members___str__():
     """Test expected enumeration members string."""
-    assert tuple([str(member) for member in Preference]) == EXPECTED_VALUES
+    assert tuple(str(member) for member in Preference) == EXPECTED_VALUES
 
 
 def test_values():

--- a/tests/geodesic/test_EnclosedPreference.py
+++ b/tests/geodesic/test_EnclosedPreference.py
@@ -21,12 +21,12 @@ def test_member_count():
 
 def test_members():
     """Test expected enumeration members."""
-    assert tuple([member.value for member in EnclosedPreference]) == EXPECTED_VALUES
+    assert tuple(member.value for member in EnclosedPreference) == EXPECTED_VALUES
 
 
 def test_members___str__():
     """Test expected enumeration members string."""
-    assert tuple([str(member) for member in EnclosedPreference]) == EXPECTED_VALUES
+    assert tuple(str(member) for member in EnclosedPreference) == EXPECTED_VALUES
 
 
 def test_values():

--- a/tests/pantry/meshes/test_fvcom_tamar.py
+++ b/tests/pantry/meshes/test_fvcom_tamar.py
@@ -29,7 +29,7 @@ def test_preference_fail(preference):
 
 @pytest.mark.parametrize(
     "preference",
-    PREFERENCES + tuple([Preference(preference) for preference in PREFERENCES]),
+    PREFERENCES + tuple(Preference(preference) for preference in PREFERENCES),
 )
 def test_preference(preference):
     """Test mesh geometry preference."""

--- a/tests/search/test_SearchPreference.py
+++ b/tests/search/test_SearchPreference.py
@@ -21,12 +21,12 @@ def test_member_count():
 
 def test_members():
     """Test expected enumeration members."""
-    assert tuple([member.value for member in SearchPreference]) == EXPECTED_VALUES
+    assert tuple(member.value for member in SearchPreference) == EXPECTED_VALUES
 
 
 def test_members___str__():
     """Test expected enumeration members string."""
-    assert tuple([str(member) for member in SearchPreference]) == EXPECTED_VALUES
+    assert tuple(str(member) for member in SearchPreference) == EXPECTED_VALUES
 
 
 def test_values():


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adopts the `ruff` preview rule [CPY001](https://docs.astral.sh/ruff/rules/missing-copyright-notice/) (`flake8-copyright`) to ensure that the `geovista` copyright preamble is present at the top of a file.

Additionally, also complies with `ruff` rule [C409](https://docs.astral.sh/ruff/rules/unnecessary-literal-within-tuple-call/).

---
