### PR TITLE
pytest: ignore astroid DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ filterwarnings = [
   "error",
   "ignore::cartopy.io.DownloadWarning",
   "ignore:geovista unable to remesh 1 cell:UserWarning",
+  "ignore:importing 'Const' from 'astroid' is deprecated and will be removed in v5, import it from 'astroid.nodes' instead:DeprecationWarning",
   "ignore:numpy.ndarray size changed:RuntimeWarning",
   "ignore:pyvista test cache image dir:UserWarning",
   "ignore:pyvista test generated image dir:UserWarning",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The recent `astroid` 4.0 release appears to be causing `ipython` for `py3` to issue deprecation warnings.

It's acceptable for us to ignore this third-party warning during testing.

Closes #1734

---
