### PR TITLE
docs: light/dark mode friendly mermaid line color

### DIFF
--- a/docs/src/developer/packaging.rst
+++ b/docs/src/developer/packaging.rst
@@ -116,6 +116,7 @@ inheritance relationship between its environments:
    config:
       theme: base
       themeVariables:
+         lineColor: "#F8B229"
          nodeBorder: "#2569E9"
          primaryColor: "#DCE7FC"
          secondaryColor: "#F4DDFF"
@@ -200,6 +201,7 @@ inheritance relationship between its environments:
    config:
       theme: base
       themeVariables:
+         lineColor: "#F8B229"
          nodeBorder: "#2569E9"
          primaryColor: "#DCE7FC"
          secondaryColor: "#F4DDFF"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

A minimal fix to address light/dark mode.

For example, this ...

```mermaid
   %%{ 
     init: {
       "theme": "base",
       "themeVariables": {
         "lineColor": "#F8B229",
         "nodeBorder": "#2569E9",
         "primaryColor": "#DCE7FC",
         "secondaryColor": "#F4DDFF"
       }
     }
   }%%
   graph LR
      default(["`**default**`"])
      devs(["`**devs**`"])
      docs(["`**docs**`"])
      test(["`**test**`"])
      geovista(["`**geovista**`"])
      default -. "`*core*`" .-> devs
      devs ---> docs
      devs ---> test
      docs ---> geovista
      test ---> geovista
```

instead of this ...

```mermaid
   %%{ 
     init: {
       "theme": "base",
       "themeVariables": {
         "nodeBorder": "#2569E9",
         "primaryColor": "#DCE7FC",
         "secondaryColor": "#F4DDFF"
       }
     }
   }%%
   graph LR
      default(["`**default**`"])
      devs(["`**devs**`"])
      docs(["`**docs**`"])
      test(["`**test**`"])
      geovista(["`**geovista**`"])
      default -. "`*core*`" .-> devs
      devs ---> docs
      devs ---> test
      docs ---> geovista
      test ---> geovista
```

---
