### PR TITLE
format bibtex

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,3 +137,18 @@ repos:
     rev: v1.19.0
     hooks:
       - id: zizmor
+
+  # ⚠️ requires nodejs
+  #
+  #    > pixi add nodejs
+  #    > pre-commit run bibtex-tidy --files docs/src/refs.bib
+  #
+  # - repo: https://github.com/FlamingTempura/bibtex-tidy
+  #   rev: v1.14.0
+  #   hooks:
+  #     - id: bibtex-tidy
+  #       args: ["--curly", "--tab", "--months", "--align", "--blank-lines", "--sort=key", "--duplicates=key", "--sort-fields", "--wrap"]
+  #       files: "^docs/src/refs.bib"
+  #       entry: ./bin/bibtex-tidy --modify
+  #       language: script
+  #       types: ['bib']

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,13 +1,20 @@
-% This is the first ever scientific article to use and cite geovista 🎉
 @article{gmd-16-5601-2023,
-    author  = {Sergeev, D. E. and Mayne, N. J. and Bendall, T. and Boutle, I. A. and Brown, A. and Kav\v{c}i\v{c}, I. and Kent, J. and Kohary, K. and Manners, J. and Melvin, T. and Olivier, E. and Ragta, L. K. and Shipway, B. and Wakelin, J. and Wood, N. and Zerroukat, M.},
-    title   = {Simulations of idealised 3{D} atmospheric flows on terrestrial planets using {LFR}ic-{A}tmosphere},
-    journal = {Geoscientific Model Development},
-    year    = {2023},
-    month   = {10},
-    volume  = {16},
-    number  = {19},
-    pages   = {5601--5626},
-    doi     = {10.5194/gmd-16-5601-2023},
-    url     = {https://gmd.copernicus.org/articles/16/5601/2023/}
+	title = {
+		Simulations of idealised 3{D} atmospheric flows on terrestrial planets using
+		{LFR}ic-{A}tmosphere
+	},
+	author = {
+		Sergeev, D. E. and Mayne, N. J. and Bendall, T. and Boutle, I. A. and Brown,
+		A. and Kav\v{c}i\v{c}, I. and Kent, J. and Kohary, K. and Manners, J. and
+		Melvin, T. and Olivier, E. and Ragta, L. K. and Shipway, B. and Wakelin, J.
+		and Wood, N. and Zerroukat, M.
+	},
+	year = {2023},
+	month = oct,
+	journal = {Geoscientific Model Development},
+	volume = {16},
+	number = {19},
+	pages = {5601--5626},
+	doi = {10.5194/gmd-16-5601-2023},
+	url = {https://gmd.copernicus.org/articles/16/5601/2023/}
 }


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

So close ...

The richest featured (popular and maintained) `bibtex` formatter and checker with `pre-commit` support that I've found is `bibtex-tidy`.

However it requires `nodejs`. Unfortunately this is an overhead that I don't want us to incur.

The compromise for now is to simply capture the `bibtex-tidy` configuration that was applied to reformat this pull-requests `refs.bib` commit, but disable the hook.

Meh.

---
