### PR TITLE
docs: fix include directive URL

### DIFF
--- a/docs/src/developer/documentation.rst
+++ b/docs/src/developer/documentation.rst
@@ -501,7 +501,7 @@ e.g.,
 .. _ci-docs.yml: https://github.com/bjlittle/geovista/blob/main/.github/workflows/ci-docs.yml
 .. _ci-tests-docs.yml: https://github.com/bjlittle/geovista/blob/main/.github/workflows/ci-tests-docs.yml
 .. _filtering: https://docs.pyvista.org/examples/01-filter/
-.. _include directive: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#include-directive
+.. _include directive: https://docutils.sourceforge.io/docs/ref/rst/directives.html#include
 .. _myst-nb configuration: https://myst-nb.readthedocs.io/en/latest/configuration.html
 .. _plotting: https://docs.pyvista.org/examples/02-plot/#
 .. _.readthedocs.yml: https://github.com/bjlittle/geovista/blob/main/.readthedocs.yml


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Recent changes to the `sphinx` documentation is causing the following `sphinx-tippy` warning when building our documentation:

```
WARNING: Could not fetch RTD data for https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#include-directive: 'content' [tippy.rtd] [tippy.rtd]
```

Instead, use alternative URL to `docutils` directly instead.

---
