### PR TITLE
add flaky naturalearth.com to lychee ignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,3 +7,5 @@ https://earthexplorer.usgs.gov/
 https://github.com/holoviz/holoviz/blob/main/examples/data/preprocessing/earthquake_data.py
 
 https://github.com/bjlittle/geovista/blob/main/.github/workflows/ci-locks.yml
+
+https://www.naturalearthdata.com/


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request adds `naturalearth.com` to the `lychee` ignore list as this service appears to be flaky (at times) resulting the continuous `lychee` timeouts.

Closes #1969

---
