### PR TITLE
docs: update developer `tests-unit` task

### DIFF
--- a/docs/src/developer/packaging.rst
+++ b/docs/src/developer/packaging.rst
@@ -413,7 +413,7 @@ The following tasks are defined for each of our features:
    |                |                 | Note that the ``tests-clean`` task is called prior to running this task.              |
    |                |                 |                                                                                       |
    |                |                 | .. note::                                                                             |
-   |                |                 |    :class: dropdown, toggle-shown                                                     |
+   |                |                 |    :class: dropdown                                                                   |
    |                |                 |                                                                                       |
    |                |                 |    Failed :ref:`tippy-gv-developer-testing-image-tests` are captured via the          |
    |                |                 |    ``pytest-pyvista`` plugin option ``--failed_image_dir`` (see                       |

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -56,7 +56,7 @@ The following testing workflows are available:
    |           | Also see the testing :ref:`tippy-gv-developer-testing-pixi-workflow` :guilabel:`tests-unit` task.             |
    |           |                                                                                                               |
    |           | .. note::                                                                                                     |
-   |           |    :class: dropdown, toggle-shown                                                                             |
+   |           |    :class: dropdown                                                                                           |
    |           |                                                                                                               |
    |           |    Failed :ref:`tippy-gv-developer-testing-image-tests` are captured via the ``pytest-pyvista`` plugin option |
    |           |    ``--failed_image_dir`` (see :ref:`tippy-gv-developer-testing-image-tests-generation`), and uploaded and    |
@@ -208,7 +208,7 @@ All image unit tests require to use the following ``pytest`` `fixtures`_:
    |                        | initiate the image comparison.                                      |
    |                        |                                                                     |
    |                        | .. seealso::                                                        |
-   |                        |    :class: dropdown, toggle-shown                                   |
+   |                        |    :class: dropdown                                                 |
    |                        |                                                                     |
    |                        |    For further details see :toml:`[tool.pytest.ini_options]` table  |
    |                        |    in the :bash:`pyproject.toml` manifest.                          |
@@ -326,6 +326,10 @@ Typically, we recommend the following:
 
    Refer to `pytest-pyvista`_ for further CLI and configuration options.
 
+   Also see the :guilabel:`tests-unit` ``pixi`` :term:`task <Task>` in the
+   following :ref:`tippy-gv-developer-testing-pixi-workflow` section, as a
+   convenience.
+
 To register a new baseline image for a unit test:
 
 #. Generate the baseline image using the ``--generated_image_dir`` option to the
@@ -421,14 +425,18 @@ e.g.,
    |                         | running this task.                                            |
    |                         |                                                               |
    |                         | .. note::                                                     |
-   |                         |    :class: dropdown, toggle-shown                             |
+   |                         |    :class: dropdown                                           |
    |                         |                                                               |
    |                         |    Failed :ref:`tippy-gv-developer-testing-image-tests` are   |
-   |                         |    captured via the ``pytest-pyvista`` plugin option          |
-   |                         |    ``--failed_image_dir`` (see                                |
+   |                         |    automatically captured via the ``pytest-pyvista`` plugin   |
+   |                         |    option ``--failed_image_dir`` (see                         |
    |                         |    :ref:`tippy-gv-developer-testing-image-tests-generation`)  |
    |                         |    and available within the :bash:`failed_images` directory   |
    |                         |    for analysis and investigation.                            |
+   |                         |                                                               |
+   |                         |    Additionally all generated images are captured via the     |
+   |                         |    ``--generated_image_dir`` plugin option and are available  |
+   |                         |    within the :bash:`test_images` directory.                  |
    +-------------------------+---------------------------------------------------------------+
 
 .. tip::


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request xrefs the `tests-unit` `pixi` task from the image tests generation section.

Also clarifies that the `tests-unit` task automatically captures all generated images of the image unit tests and additionally any failures using the `pytest-pyvista` plugin.

---
