### PR TITLE
add mesh utility to sanitize arrays

### DIFF
--- a/changelog/1985.feature.rst
+++ b/changelog/1985.feature.rst
@@ -1,0 +1,3 @@
+Added the utility function :func:`geovista.common.sanitize` to
+purge standard index arrays from one or more meshes.
+(:user:`bjlittle`)

--- a/src/geovista/geodesic.py
+++ b/src/geovista/geodesic.py
@@ -26,7 +26,7 @@ from .common import (
     ZLEVEL_SCALE,
     StrEnumPlus,
     distance,
-    sanitize_vtk,
+    sanitize,
     to_cartesian,
     wrap,
 )
@@ -1012,7 +1012,7 @@ class BBox:  # numpydoc ignore=PR01
         region.active_scalars_name = active_scalars_name
 
         # tidy data markers
-        sanitize_vtk(region)
+        sanitize(region, extra=scalars)
 
         return cast(region)
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request removes `geovista` internal cell and point index arrays from one or more mesh.

Additional `extra` arrays may be specified and optionally `geovista.common.sanitize_vtk` is called.

---
