### PR TITLE
Pass `mesh_args` from add_medians/parallels

### DIFF
--- a/changelog/2018.bugfix.rst
+++ b/changelog/2018.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed issue where ``mesh_args`` were not always being passed
+to the GeoPlotter when adding graticule meridians/parallels.
+(:user:`ukmo-ccbunney`)

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -940,7 +940,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
                 mesh_enclosed = self.bbox.enclosed(mesh)
                 self.add_mesh(mesh_enclosed, **mesh_args)
             else:
-                self.add_mesh(mesh)
+                self.add_mesh(mesh, **mesh_args)
 
         if show_labels:
             self._add_graticule_labels(
@@ -1131,7 +1131,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
                 mesh_enclosed = self.bbox.enclosed(mesh)
                 self.add_mesh(mesh_enclosed, **mesh_args)
             else:
-                self.add_mesh(mesh)
+                self.add_mesh(mesh, **mesh_args)
 
         if show_labels:
             self._add_graticule_labels(


### PR DESCRIPTION
## 🚀 Pull Request

### Description
It would be nice for the user to control the colour of the graticule lines generated by `GeoPlotter.add_meridians` and `GeoPlotter.add_parallels` (or the convenience function `GeoPlotter.add_graticule`.

The mechanism is in place to do this (via the `mesh_args` keyword), but this is not always passed to the `GeoPlotter.add_mesh` method.

This PR fixes that so you can do something like:

```python
import geovista as gv
p = gv.GeoPlotter()
p.add_graticule(show_labels=False, mesh_args={'color': 'red'})
p.show()
```

and get this:
<img width="295" height="281" alt="image" src="https://github.com/user-attachments/assets/60a857eb-9e92-4dbc-85df-c69d4b0c220c" />
