### PR TITLE
deps: unpin `trame-vtk` and `trame-vuetify`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,8 +527,8 @@ towncrier = ">=24.8.0,<26"
 trame = "==3.12.0"
 trame-client = ">=3.9.0,<4"
 trame-server = ">=3.4.0,<4"
-trame-vtk = "==2.8.15"                            # https://github.com/pyvista/pyvista/issues/7721 unpin when https://github.com/Kitware/trame-vtk/issues/94 resolved
-trame-vuetify = "==3.1.0"
+trame-vtk = "==2.10.2"
+trame-vuetify = "==3.2.0"
 
 [tool.pixi.feature.docs.pypi-dependencies]
 sphinx-tippy = ">=0.4.3,<0.5"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Unpinning `trame-vtk` and `trame-vuetify` (to mirror `pyvista` docs deps) now that https://github.com/pyvista/trame-pyvista/issues/9 has been resolved downstream.

---
