### PR TITLE
bug: fix geoplotter for clip plane widget algorithm

### DIFF
--- a/changelog/2050.bugfix.rst
+++ b/changelog/2050.bugfix.rst
@@ -1,0 +1,4 @@
+Added defensive guard within :meth:`geovista.geoplotter.GeoPlotterBase.add_mesh`
+prior to accessing the :attr:`~pyvista.DataObject.is_empty` property, which does
+not exist on all `pyvista`_ instances.
+(:user:`bjlittle`)

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -718,7 +718,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
 
             src_crs = from_wkt(mesh)
 
-            if src_crs is None and not mesh.is_empty:
+            if src_crs is None and hasattr(mesh, "is_empty") and not mesh.is_empty:
                 wmsg = (
                     "geovista found no coordinate reference system (CRS) attached "
                     "to mesh."
@@ -820,7 +820,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
 
         # explicitly don't add an empty mesh, regardless of
         # theme allow_empty_mesh option
-        return None if mesh.is_empty else super().add_mesh(mesh, **kwargs)  # type: ignore[misc]
+        if hasattr(mesh, "is_empty") and mesh.is_empty:
+            result = None
+        else:
+            result = super().add_mesh(mesh, **kwargs)  # type: ignore[misc]
+
+        return result
 
     def add_meridian(
         self,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Minor defensive tweak required within `GeoPlotterBase.add_mesh` to protect against the use of the `is_empty` property, which may not exist e.g., when adding a clip plane widget for a mesh to a geoplotter instance:

<img width="1264" height="712" alt="image" src="https://github.com/user-attachments/assets/f1918f86-bc02-444a-9043-c5ce2576761d" />

---
