### PR TITLE
update report for `nest-asyncio2`

### DIFF
--- a/changelog/2072.dependency.rst
+++ b/changelog/2072.dependency.rst
@@ -1,0 +1,3 @@
+Refreshed the :class:`geovista.report.Report` to reflect the package migration
+from ``nest-asyncio`` to ``nest-asyncio2`` for ``pyvista >=0.47.0``.
+(:user:`bjlittle`)

--- a/src/geovista/report.py
+++ b/src/geovista/report.py
@@ -77,7 +77,7 @@ PACKAGES_OPTIONAL: list[str] = [
     "ipywidgets",
     "jupyter-server-proxy",
     "jupyterlab",
-    "nest-asyncio",
+    "nest-asyncio2",
     "tqdm",
     "trame",
     "trame-client",


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Migration from `nest-asyncio` to `nest-asyncio2` specifically applies from `pyvista >=0.47.0`.

This is a documentation dependency required by the `trame` backend of `pyvista` to serialize interactive `vtksz` scenes.

---
