### PR TITLE
name graticule actors

### DIFF
--- a/changelog/2102.feature.rst
+++ b/changelog/2102.feature.rst
@@ -1,0 +1,3 @@
+Added graticule actor naming for meridians, parallels and labels thus allowing
+them to be easily updated or removed from the plotter scene.
+(:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ max-complexity = 26
 
 [tool.ruff.lint.pylint]
 # TODO @bjlittle: refactor to reduce the complexity, if possible
-max-args = 14
+max-args = 15
 max-branches = 29
 max-statements = 91
 

--- a/src/geovista/cli.py
+++ b/src/geovista/cli.py
@@ -506,7 +506,7 @@ def main(
     is_flag=True,
     help="Verify availability of registered assets (no download).",
 )
-def download(  # noqa: PLR0913
+def download(
     pull: bool,
     clean: bool,
     decompress: bool,

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -264,6 +264,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         zlevel: int | None = None,
         zscale: float | None = None,
         point_labels_args: dict[Any, Any] | None = None,
+        name: str | None = None,
     ) -> None:
         """Render the labels for the given parallels/meridians.
 
@@ -283,6 +284,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             :data:`geovista.common.ZLEVEL_SCALE`.
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+        name : str, optional
+            The name for the added labels/actor so that they can be easily updated.
+            If an actor of this name already exists in the plotter scene, it
+            will be replaced by the new actor. Note that the provided `name` will be
+            prepended with ``-labels`` to form the final name of the added
+            labels/actor.
 
         Notes
         -----
@@ -336,7 +343,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             point_labels_args["always_visible"] = False
 
             self.add_point_labels: Callable[..., None]
-            self.add_point_labels(xyz, labels, **point_labels_args)
+            self.add_point_labels(xyz, labels, name=name, **point_labels_args)
 
     def _warn_opacity(self) -> None:
         """Add textual warning for no opacity support to plotter scene.
@@ -540,6 +547,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         zscale: float | None = None,
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
+        name: str | None = None,
     ) -> None:
         """Generate a graticule and add to the plotter scene.
 
@@ -580,8 +588,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
         factor : float, optional
             The factor to scale the number of sample points in a single graticule line
-            (meridians and parallels). E.g. a ``factor=2`` will double the number of
-            sample points. Defaults to 1.
+            (meridians and parallels) e.g. a ``factor=2`` will double the number of
+            sample points. Defaults to ``1``.
         poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
@@ -605,6 +613,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+        name : str, optional
+            The name for the added graticule actors so that they can be easily updated.
+            If actors of this name already exist in the plotter scene, they
+            will be replaced by the new actors. Note that the provided `name` will be
+            prepended with ``-meridian``, ``-parallel``, or ``-labels`` to form the
+            final names of the added graticule actors. Defaults to ``graticule``.
 
         Notes
         -----
@@ -615,6 +629,9 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             num_samples = (n_samples, n_samples)
         else:
             num_samples = n_samples
+
+        if name is None:
+            name = "graticule"
 
         self.add_meridians(
             start=lon_start,
@@ -629,6 +646,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             zscale=zscale,
             mesh_args=mesh_args,
             point_labels_args=point_labels_args,
+            name=name,
         )
         self.add_parallels(
             start=lat_start,
@@ -645,6 +663,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             zscale=zscale,
             mesh_args=mesh_args,
             point_labels_args=point_labels_args,
+            name=name,
         )
 
     def add_mesh(
@@ -841,6 +860,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         zscale: float | None = None,
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
+        name: str | None = None,
     ) -> None:
         """Generate a line of constant longitude and add to the plotter scene.
 
@@ -857,8 +877,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             :data:`geovista.gridlines.LONGITUDE_N_SAMPLES`.
         factor : float, optional
             The factor to scale the number of sample points in a single line of
-            longitude. E.g. a ``factor=2`` will double the number of sample points.
-            Defaults to 1.
+            longitude e.g., a ``factor=2`` will double the number of sample points.
+            Defaults to ``1``.
         show_labels : bool, optional
             Whether to render the meridian label. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
@@ -875,6 +895,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+        name : str, optional
+            The name for the added meridian/actor so that it can be easily updated.
+            If an actor of this name already exists in the plotter scene, it
+            will be replaced by the new actor. Note that the provided `name` will be
+            prepended with ``-meridian`` to form the final name of the added
+            meridian/actor.
 
         Notes
         -----
@@ -893,6 +919,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             zscale=zscale,
             mesh_args=mesh_args,
             point_labels_args=point_labels_args,
+            name=name,
         )
 
     def add_meridians(
@@ -910,6 +937,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         zscale: float | None = None,
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
+        name: str | None = None,
     ) -> None:
         """Generate lines of constant longitude and add to the plotter scene.
 
@@ -935,8 +963,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             :data:`geovista.gridlines.LONGITUDE_N_SAMPLES`.
         factor : float, optional
             The factor to scale the number of sample points in a single line of
-            longitude. E.g. a ``factor=2`` will double the number of sample points.
-            Defaults to 1.
+            longitude e.g., a ``factor=2`` will double the number of sample points.
+            Defaults to ``1``.
         show_labels : bool, optional
             Whether to render the labels of the meridians. Defaults to
             :data:`GRATICULE_SHOW_LABELS`.
@@ -953,6 +981,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+        name : str, optional
+            The name for the added meridians/actor so that it can be easily updated.
+            If an actor of this name already exists in the plotter scene, it
+            will be replaced by the new actor. Note that the provided `name` will be
+            prepended with ``-meridian`` to form the final name of the added
+            meridians/actor.
 
         Notes
         -----
@@ -999,8 +1033,10 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         if zscale is not None:
             mesh_args["zscale"] = zscale
 
-        for mesh in meridians.blocks:
-            self.add_mesh(mesh, **mesh_args)
+        if name is not None:
+            name = f"{name}-meridian"
+
+        self.add_mesh(meridians.blocks, name=name, **mesh_args)
 
         if show_labels:
             self._add_graticule_labels(
@@ -1009,6 +1045,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
                 zlevel=zlevel,
                 zscale=zscale,
                 point_labels_args=point_labels_args,
+                name=name,
             )
 
     def add_parallel(
@@ -1026,6 +1063,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         zscale: float | None = None,
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
+        name: str | None = None,
     ) -> None:
         """Generate a line of constant latitude and add to the plotter scene.
 
@@ -1042,8 +1080,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
         factor : float, optional
             The factor to scale the number of sample points in a single line of
-            latitude. E.g. a ``factor=2`` will double the number of sample points.
-            Defaults to 1.
+            latitude e.g., a ``factor=2`` will double the number of sample points.
+            Defaults to ``1``.
         poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
@@ -1063,6 +1101,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+        name : str, optional
+            The name for the added parallel/actor so that it can be easily updated.
+            If an actor of this name already exists in the plotter scene, it
+            will be replaced by the new actor. Note that the provided `name` will be
+            prepended with ``-parallel`` to form the final name of the added
+            parallel/actor.
 
         Notes
         -----
@@ -1082,6 +1126,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             zscale=zscale,
             mesh_args=mesh_args,
             point_labels_args=point_labels_args,
+            name=name,
         )
 
     def add_parallels(
@@ -1101,6 +1146,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         zscale: float | None = None,
         mesh_args: dict[Any, Any] | None = None,
         point_labels_args: dict[Any, Any] | None = None,
+        name: str | None = None,
     ) -> None:
         """Generate lines of constant latitude and add to the plotter scene.
 
@@ -1126,8 +1172,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             :data:`geovista.gridlines.LATITUDE_N_SAMPLES`.
         factor : float, optional
             The factor to scale the number of sample points in a single line of
-            latitude. E.g. a ``factor=2`` will double the number of sample points.
-            Defaults to 1.
+            latitude e.g., a ``factor=2`` will double the number of sample points.
+            Defaults to ``1``.
         poles_parallel : bool, optional
             Whether to create a line of latitude at the north/south poles. Defaults to
             :data:`geovista.gridlines.LATITUDE_POLES_PARALLEL`.
@@ -1151,6 +1197,12 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             Arguments to pass through to :meth:`pyvista.Plotter.add_mesh`.
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
+        name : str, optional
+            The name for the added parallels/actor so that it can be easily updated.
+            If an actor of this name already exists in the plotter scene, it
+            will be replaced by the new actor. Note that the provided `name` will be
+            prepended with ``-parallel`` to form the final name of the added
+            parallels/actor.
 
         Notes
         -----
@@ -1197,8 +1249,10 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         if zscale is not None:
             mesh_args["zscale"] = zscale
 
-        for mesh in parallels.blocks:
-            self.add_mesh(mesh, **mesh_args)
+        if name is not None:
+            name = f"{name}-parallel"
+
+        self.add_mesh(parallels.blocks, name=name, **mesh_args)
 
         if show_labels:
             self._add_graticule_labels(
@@ -1207,6 +1261,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
                 zlevel=zlevel,
                 zscale=zscale,
                 point_labels_args=point_labels_args,
+                name=name,
             )
 
     def add_points(

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -288,8 +288,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             The name for the added labels/actor so that they can be easily updated.
             If an actor of this name already exists in the plotter scene, it
             will be replaced by the new actor. Note that the provided `name` will be
-            prepended with ``-labels`` to form the final name of the added
-            labels/actor.
+            appended with ``-labels`` to form the name of the added labels/actor.
 
         Notes
         -----
@@ -617,8 +616,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             The name for the added graticule actors so that they can be easily updated.
             If actors of this name already exist in the plotter scene, they
             will be replaced by the new actors. Note that the provided `name` will be
-            prepended with ``-meridian``, ``-parallel``, or ``-labels`` to form the
-            final names of the added graticule actors. Defaults to ``graticule``.
+            prepended with ``meridian-`` or ``parallel-`` to form the names of the
+            graticule actors.
 
         Notes
         -----
@@ -629,9 +628,6 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             num_samples = (n_samples, n_samples)
         else:
             num_samples = n_samples
-
-        if name is None:
-            name = "graticule"
 
         self.add_meridians(
             start=lon_start,
@@ -896,11 +892,11 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
         name : str, optional
-            The name for the added meridian/actor so that it can be easily updated.
+            The name for the added meridian/actors so that it can be easily updated.
             If an actor of this name already exists in the plotter scene, it
             will be replaced by the new actor. Note that the provided `name` will be
-            prepended with ``-meridian`` to form the final name of the added
-            meridian/actor.
+            prepended with ``meridian-`` along with the longitude to form the name
+            of the added meridian/actors.
 
         Notes
         -----
@@ -982,11 +978,11 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
         name : str, optional
-            The name for the added meridians/actor so that it can be easily updated.
+            The name for the added meridians/actors so that it can be easily updated.
             If an actor of this name already exists in the plotter scene, it
             will be replaced by the new actor. Note that the provided `name` will be
-            prepended with ``-meridian`` to form the final name of the added
-            meridians/actor.
+            prepended with ``meridian-`` along with the longitude to form the name of
+            the added meridians/actors.
 
         Notes
         -----
@@ -1033,19 +1029,33 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         if zscale is not None:
             mesh_args["zscale"] = zscale
 
-        if name is not None:
-            name = f"{name}-meridian"
+        labels = (
+            label.replace("°", "")
+            for label in meridians.labels[: len(meridians.blocks)]
+        )
+        mesh_names = []
 
-        self.add_mesh(meridians.blocks, name=name, **mesh_args)
+        for label, mesh in zip(labels, meridians.blocks, strict=True):
+            address = f"{type(mesh).__name__}({mesh.GetAddressAsString('')})"
+            postfix = f"{address}" if name is None else f"{name}-{address}"
+            mesh_name = f"meridian-{label}-{postfix}"
+            mesh_names.append(mesh_name)
+            self.add_mesh(mesh, name=mesh_name, **mesh_args)
 
         if show_labels:
+            if len(mesh_names) == 1:
+                (labels_name,) = mesh_names
+            else:
+                labels_name = "meridian" if name is None else f"meridian-{name}"
+
+            # note that pyvista will automatically append "-labels" to the actor name
             self._add_graticule_labels(
                 meridians,
                 radius=radius,
                 zlevel=zlevel,
                 zscale=zscale,
                 point_labels_args=point_labels_args,
-                name=name,
+                name=labels_name,
             )
 
     def add_parallel(
@@ -1105,8 +1115,8 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
             The name for the added parallel/actor so that it can be easily updated.
             If an actor of this name already exists in the plotter scene, it
             will be replaced by the new actor. Note that the provided `name` will be
-            prepended with ``-parallel`` to form the final name of the added
-            parallel/actor.
+            prepended with ``parallel-`` along with the latitude to form the name of
+            the added parallel/actor.
 
         Notes
         -----
@@ -1198,11 +1208,11 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         point_labels_args : dict, optional
             Arguments to pass through to :meth:`pyvista.Plotter.add_point_labels`.
         name : str, optional
-            The name for the added parallels/actor so that it can be easily updated.
+            The name for the added parallels/actors so that it can be easily updated.
             If an actor of this name already exists in the plotter scene, it
             will be replaced by the new actor. Note that the provided `name` will be
-            prepended with ``-parallel`` to form the final name of the added
-            parallels/actor.
+            prepended with ``-parallel`` along with the latitude to form the name of
+            the added parallels/actors.
 
         Notes
         -----
@@ -1249,19 +1259,33 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         if zscale is not None:
             mesh_args["zscale"] = zscale
 
-        if name is not None:
-            name = f"{name}-parallel"
+        labels = (
+            label.replace("°", "")
+            for label in parallels.labels[: len(parallels.blocks)]
+        )
+        mesh_names = []
 
-        self.add_mesh(parallels.blocks, name=name, **mesh_args)
+        for label, mesh in zip(labels, parallels.blocks, strict=True):
+            address = f"{type(mesh).__name__}({mesh.GetAddressAsString('')})"
+            postfix = f"{address}" if name is None else f"{name}-{address}"
+            mesh_name = f"parallel-{label}-{postfix}"
+            mesh_names.append(mesh_name)
+            self.add_mesh(mesh, name=mesh_name, **mesh_args)
 
         if show_labels:
+            if len(mesh_names) == 1:
+                (labels_name,) = mesh_names
+            else:
+                labels_name = "parallel" if name is None else f"parallel-{name}"
+
+            # note that pyvista will automatically append "-labels" to the actor name
             self._add_graticule_labels(
                 parallels,
                 radius=radius,
                 zlevel=zlevel,
                 zscale=zscale,
                 point_labels_args=point_labels_args,
-                name=name,
+                name=labels_name,
             )
 
     def add_points(

--- a/src/geovista/gridlines.py
+++ b/src/geovista/gridlines.py
@@ -250,8 +250,8 @@ def create_meridians(
         :data:`LONGITUDE_N_SAMPLES`.
     factor : float, optional
         The factor to scale the number of sample points in a single line of
-        longitude.  E.g. a ``factor=2`` will double the number of sample points.
-        Defaults to 1.
+        longitude e.g., a ``factor=2`` will double the number of sample points.
+        Defaults to ``1``.
     closed_interval : bool, default=False
         Longitude values will be in the half-closed interval [-180, 180). Otherwise,
         longitudes will be in the closed interval [-180, 180]. Defaults to
@@ -468,8 +468,8 @@ def create_parallels(
         :data:`LATITUDE_N_SAMPLES`.
     factor : float, optional
         The factor to scale the number of sample points in a single line of
-        latitude.  E.g. a ``factor=2`` will double the number of sample points.
-        Defaults to 1.
+        latitude e.g., a ``factor=2`` will double the number of sample points.
+        Defaults to ``1``.
     poles_parallel : bool, optional
         Whether to create a line of latitude at the north/south poles. Also see
         ``poles_label``. Defaults to :data:`LATITUDE_POLES_PARALLEL`.

--- a/tests/geoplotter/test_add_graticule.py
+++ b/tests/geoplotter/test_add_graticule.py
@@ -12,8 +12,8 @@ import pytest
 from geovista.geoplotter import GeoPlotter
 
 
-@pytest.mark.parametrize("name", [None, "test"])
-def test_actor_naming(name):
+@pytest.mark.parametrize("name", [None, "test"], ids=["no-name", "name"])
+def test_graticule_actor_naming(name):
     """Test graticule actor naming."""
     p = GeoPlotter()
     p.add_graticule(name=name, show_labels=True)

--- a/tests/geoplotter/test_add_graticule.py
+++ b/tests/geoplotter/test_add_graticule.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.geoplotter.GeoPlotter.add_graticule`."""
+
+from __future__ import annotations
+
+import pytest
+
+from geovista.geoplotter import GeoPlotter
+
+
+@pytest.mark.parametrize("name", [None, "test"])
+def test_actor_naming(name):
+    """Test graticule actor naming."""
+    p = GeoPlotter()
+    p.add_graticule(name=name)
+    if name is None:
+        name = "graticule"
+    expected = {
+        f"{name}-meridian",
+        f"{name}-parallel",
+        f"{name}-meridian-labels",
+        f"{name}-parallel-labels",
+    }
+    assert set(p.actors.keys()) == expected

--- a/tests/geoplotter/test_add_graticule.py
+++ b/tests/geoplotter/test_add_graticule.py
@@ -16,13 +16,35 @@ from geovista.geoplotter import GeoPlotter
 def test_actor_naming(name):
     """Test graticule actor naming."""
     p = GeoPlotter()
-    p.add_graticule(name=name)
+    p.add_graticule(name=name, show_labels=True)
+    actors = p.actors.keys()
+    meridians = [
+        actor.split("-")
+        for actor in actors
+        if actor.startswith("meridian")
+        if "labels" not in actor
+    ]
+    parallels = [
+        actor.split("-")
+        for actor in actors
+        if actor.startswith("parallel")
+        if "labels" not in actor
+    ]
+    assert len(meridians) == 8
+    assert len(parallels) == 5
+
     if name is None:
-        name = "graticule"
-    expected = {
-        f"{name}-meridian",
-        f"{name}-parallel",
-        f"{name}-meridian-labels",
-        f"{name}-parallel-labels",
-    }
-    assert set(p.actors.keys()) == expected
+        expected_meridian_labels = "meridian-labels"
+        expected_parallel_labels = "parallel-labels"
+    else:
+        expected_meridian_labels = f"meridian-{name}-labels"
+        expected_parallel_labels = f"parallel-{name}-labels"
+
+    assert expected_meridian_labels in actors
+    assert expected_parallel_labels in actors
+
+    expected_meridians = {"180", "135W", "90W", "45W", "0", "45E", "90E", "135E"}
+    expected_parallels = {"60S", "30S", "0", "30N", "60N"}
+
+    assert {label[1] for label in meridians} == expected_meridians
+    assert {label[1] for label in parallels} == expected_parallels

--- a/tests/geoplotter/test_add_meridian.py
+++ b/tests/geoplotter/test_add_meridian.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.geoplotter.GeoPlotter.add_meridian`."""
+
+from __future__ import annotations
+
+import pytest
+
+from geovista.geoplotter import GeoPlotter
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (-180, "180"),
+        (-135, "135W"),
+        (-90, "90W"),
+        (-45, "45W"),
+        (0, "0"),
+        (45, "45E"),
+        (90, "90E"),
+        (135, "135E"),
+    ],
+)
+@pytest.mark.parametrize("name", [None, "test"], ids=["no-name", "name"])
+def test_meridian_actor_naming(name, value, expected):
+    """Test meridian actor naming."""
+    p = GeoPlotter()
+    p.add_meridian(value, name=name, show_labels=True)
+    actors = p.actors.keys()
+    meridians = [actor.split("-") for actor in actors if "labels" not in actor]
+    assert len(meridians) == 1
+    (meridian,) = meridians
+    assert len(actors) == 2
+
+    expected_meridian_labels = f"{'-'.join(meridian)}-labels"
+    assert expected_meridian_labels in actors
+
+    assert meridian[1] == expected

--- a/tests/geoplotter/test_add_meridians.py
+++ b/tests/geoplotter/test_add_meridians.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.geoplotter.GeoPlotter.add_meridians`."""
+
+from __future__ import annotations
+
+import pytest
+
+from geovista.geoplotter import GeoPlotter
+
+
+@pytest.mark.parametrize("name", [None, "test"], ids=["no-name", "name"])
+def test_meridians_actor_naming(name):
+    """Test meridian actor naming."""
+    p = GeoPlotter()
+    p.add_meridians(name=name, show_labels=True)
+    actors = p.actors.keys()
+    meridians = [actor.split("-") for actor in actors if "labels" not in actor]
+    assert len(meridians) == 8
+
+    if name is None:
+        expected_meridian_labels = "meridian-labels"
+    else:
+        expected_meridian_labels = f"meridian-{name}-labels"
+
+    assert expected_meridian_labels in actors
+    expected_meridians = {"180", "135W", "90W", "45W", "0", "45E", "90E", "135E"}
+    assert {label[1] for label in meridians} == expected_meridians

--- a/tests/geoplotter/test_add_parallel.py
+++ b/tests/geoplotter/test_add_parallel.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.geoplotter.GeoPlotter.add_parallel`."""
+
+from __future__ import annotations
+
+import pytest
+
+from geovista.geoplotter import GeoPlotter
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (-60, "60S"),
+        (-30, "30S"),
+        (0, "0"),
+        (30, "30N"),
+        (60, "60N"),
+    ],
+)
+@pytest.mark.parametrize("name", [None, "test"], ids=["no-name", "name"])
+def test_parallel_actor_naming(name, value, expected):
+    """Test parallel actor naming."""
+    p = GeoPlotter()
+    p.add_parallel(value, name=name, show_labels=True)
+    actors = p.actors.keys()
+    parallels = [actor.split("-") for actor in actors if "labels" not in actor]
+    assert len(parallels) == 1
+    (parallel,) = parallels
+    assert len(actors) == 2
+
+    expected_parallel_labels = f"{'-'.join(parallel)}-labels"
+    assert expected_parallel_labels in actors
+
+    assert parallel[1] == expected

--- a/tests/geoplotter/test_add_parallels.py
+++ b/tests/geoplotter/test_add_parallels.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.geoplotter.GeoPlotter.add_parallels`."""
+
+from __future__ import annotations
+
+import pytest
+
+from geovista.geoplotter import GeoPlotter
+
+
+@pytest.mark.parametrize("name", [None, "test"], ids=["no-name", "name"])
+def test_parallels_actor_naming(name):
+    """Test parallel actor naming."""
+    p = GeoPlotter()
+    p.add_parallels(name=name, show_labels=True)
+    actors = p.actors.keys()
+    parallels = [actor.split("-") for actor in actors if "labels" not in actor]
+    assert len(parallels) == 5
+
+    if name is None:
+        expected_parallel_labels = "parallel-labels"
+    else:
+        expected_parallel_labels = f"parallel-{name}-labels"
+
+    assert expected_parallel_labels in actors
+    expected_parallels = {"60S", "30S", "0", "30N", "60N"}
+    assert {label[1] for label in parallels} == expected_parallels


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request ensures that the actors of the graticule added to the plotter scene are named, thus allowing them to be easily updated or removed.

The `name` kwarg has been added to the `GeoPlotterBase` methods:
- `add_graticule`
- `add_meridian`
- `add_meridians`
- `add_parallel`
- `add_parallels`

Meridian actor names will take the format:
- `meridian-<value>-PolyData(<addr>)` or
- `meridian-<value>-<name>-PolyData(<addr>)` if a kwarg `name` is provided.

Parallel actor names will take the format:
- `parallel-<value>-PolyData(<addr>)` or
- `parallel-<value>-<name>-PolyData(<addr>)` if a kwarg `name` is provided.

For labels we have:
- `meridian-labels` and `parallel-labels`, or
- `meridian-<name>-labels` and `parallel-<name>-labels` if a kwarg `name` is provided.

Note that if a single meridian/parallel is added to the plotter scene via `add_meridian`/`add_parallel` the associated labels take the form:
- `meridian-<value>-PolyData(<addr>)-labels` or `meridian-<value>-<name>-PolyData(<addr>)-labels`
- `parallel-<value>-PolyData(<addr>)-labels` or `parallel-<value>-<name>-PolyData(<addr>)-labels`

e.g.,

```python
>>> import geovista
>>> p = geovista.GeoPlotter()
>>> p.add_graticule()
>>> p.actors.keys()
dict_keys(['meridian-180-PolyData(Addr=0x59812556aa70)', 'meridian-135W-PolyData(Addr=0x598125593a30)', 'meridian-90W-PolyData(Addr=0x598125586170)', 'meridian-45W-PolyData(Addr=0x5981255e0280)', 'meridian-0-PolyData(Addr=0x59812556b5c0)', 'meridian-45E-PolyData(Addr=0x59812556a290)', 'meridian-90E-PolyData(Addr=0x598125567f00)', 'meridian-135E-PolyData(Addr=0x598125b80690)', 'meridian-labels', 'parallel-60S-PolyData(Addr=0x59812556aa70)', 'parallel-30S-PolyData(Addr=0x598125bf1c70)', 'parallel-0-PolyData(Addr=0x5981258a66e0)', 'parallel-30N-PolyData(Addr=0x59812575ba80)', 'parallel-60N-PolyData(Addr=0x598125a68ca0)', 'parallel-labels'])
>>> 
```



---
