### PR TITLE
tidy entry-point

### DIFF
--- a/changelog/2110.internal.rst
+++ b/changelog/2110.internal.rst
@@ -1,0 +1,3 @@
+Tidied the CLI entry-point to always route through ``geovista.__main__``
+and support direct script invocation.
+(:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ YouTube = "https://www.youtube.com/@geovista_devs/videos"
 
 
 [project.scripts]
-geovista = "geovista.cli:main"
+geovista = "geovista.__main__:main"
 
 
 [tool.check-manifest]

--- a/src/geovista/__main__.py
+++ b/src/geovista/__main__.py
@@ -7,6 +7,13 @@
 
 from __future__ import annotations
 
-from .cli import main
+from geovista.cli import main as entry
 
-main()
+
+def main() -> None:
+    """Execute the CLI entry-point."""
+    entry()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Use a single source of truth i.e., always go through `geovista.__main__`.

Avoid using a relative import within `__main__` and check with `__name__` for direct script invocation.

Support calling the entry point from the command-line in multiple ways e.g., call with the `--version` flag as either:

- `geovista --version`
- `python -m geovista --version`
- `python src/geovista/__main__.py --version`

---
