### PR TITLE
gha: apt-get update/install

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,6 +1,5 @@
 # Reference:
 #   - https://github.com/actions/checkout
-#   - https://github.com/awalsh128/cache-apt-pkgs-action
 #   - https://github.com/prefix-dev/setup-pixi
 
 name: ci-docs
@@ -55,11 +54,10 @@ jobs:
         run: |
           echo "CACHE_PERIOD=$(date +%Y).$(expr $(date +%U) / ${CACHE_WEEKS})" >> ${GITHUB_ENV}
 
-      - name: "apt cache"
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
-        with:
-          packages: libgl1-mesa-glx
-          version: 1.0
+      - name: "apt install"
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgl1 libglx-mesa0
 
       - name: "setup pixi"
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e

--- a/.github/workflows/ci-tests-docs.yml
+++ b/.github/workflows/ci-tests-docs.yml
@@ -1,7 +1,6 @@
 # Reference:
 #   - https://github.com/actions/checkout
 #   - https://github.com/actions/upload-artifact
-#   - https://github.com/awalsh128/cache-apt-pkgs-action
 #   - https://github.com/prefix-dev/setup-pixi
 
 name: ci-tests-docs
@@ -55,11 +54,10 @@ jobs:
         run: |
           echo "CACHE_PERIOD=$(date +%Y).$(expr $(date +%U) / ${CACHE_WEEKS})" >> ${GITHUB_ENV}
 
-      - name: "apt cache"
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
-        with:
-          packages: libgl1-mesa-glx
-          version: 1.0
+      - name: "apt install"
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgl1 libglx-mesa0
 
       - name: "setup pixi"
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,8 @@ build:
   tools:
     python: "latest"
   apt_packages:
-    - libgl1-mesa-dev
+    - libgl1
+    - libglx-mesa0
     - xvfb
   jobs:
     # https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-pixi

--- a/changelog/2128.dependency.rst
+++ b/changelog/2128.dependency.rst
@@ -1,0 +1,2 @@
+Migrated from the obsolete ``libgl1-mesa-glx`` package to the modern equivalent ``libgl1``
+and ``libglx-mesa0``. (:user:`bjlittle`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Migrate away from using the now obsolete `libgl1-mesa-glx` and instead adopt use of the modern `libgl1` and `libglx-mesa0` packages.

Additionally, perform a fresh `sudo apt-get install` rather than using the `awalsh128/cache-apt-pkgs-action` GHA which will now trigger the [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) audit rule of `zizmor`.

Performing a fresh `sudo apt-get update` and `sudo apt-get install ...` is not an expensive overhead to the workflow.

---
