### PR TITLE
deps: explicit `dependabot` versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
       - dependency-name: "*"
         # ignore patch updates
         update-types: ["version-update:semver-patch"]
-    versioning-strategy: "widen"
+    versioning-strategy: "increase-if-necessary"
     groups:
       pip:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,7 @@ updates:
       - dependency-name: "*"
         # ignore patch updates
         update-types: ["version-update:semver-patch"]
+    versioning-strategy: "widen"
     groups:
       pip:
         patterns:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

`dependabot` appears to have recently changed its `auto` [versioning strategy](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--) from `widen` to `increase`. 

This results in `dependabot` bumping any minimum pins, which is exactly what we don't want e.g., see #2230

... actually, digging further `widen` has never been an option that can be explicitly set for the `pip` ecosystem even though `auto` prior to Apr 2026 behaved in this way.

---
