### PR TITLE
docs: drop `start_xvfb`

### DIFF
--- a/changelog/2247.internal.rst
+++ b/changelog/2247.internal.rst
@@ -1,0 +1,2 @@
+Dropped the use of ``pyvista.start_xvfb`` when building the documentation.
+(:user:`bjlittle`)

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -689,10 +689,6 @@ pyvista.FIGURE_PATH = str(pyvista_images_dir)
 if not pyvista_images_dir.exists():
     pyvista_images_dir.mkdir(parents=True, exist_ok=True)
 
-# We also need to start this on CI services and GitHub Actions has a CI env var
-if on_rtd or os.environ.get("CI"):
-    pyvista.start_xvfb()
-
 scraper = DynamicScraper()
 
 

--- a/docs/src/reference/environment.rst
+++ b/docs/src/reference/environment.rst
@@ -81,9 +81,6 @@ Notable third-party environment variables that influence the behaviour of
     +======================================+===============+=========================================================+
     | :guilabel:`CI`                       | ``Platform``  | Default environment variable set on a `GitHub Action`_  |
     |                                      |               | runner.                                                 |
-    |                                      |               |                                                         |
-    |                                      |               | Used by ``geovista`` to start an X virtual frame buffer |
-    |                                      |               | display server via :func:`pyvista.start_xvfb`.          |
     +--------------------------------------+---------------+---------------------------------------------------------+
     | :guilabel:`EAGER_IMPORT`             | ``User``      | Set this environment variable to **disable** lazy       |
     |                                      |               | loading of ``geovista`` subpackages and external        |
@@ -99,9 +96,6 @@ Notable third-party environment variables that influence the behaviour of
     +--------------------------------------+---------------+---------------------------------------------------------+
     | :guilabel:`READTHEDOCS`              | ``Platform``  | Default environment variable set on a `Read the Docs`_  |
     |                                      |               | runner.                                                 |
-    |                                      |               |                                                         |
-    |                                      |               | Used by ``geovista`` to start an X virtual frame buffer |
-    |                                      |               | display server via :func:`pyvista.start_xvfb`.          |
     +--------------------------------------+---------------+---------------------------------------------------------+
     | :guilabel:`XDG_CACHE_HOME`           | ``User``      | Configures the root directory (absolute path) where     |
     |                                      |               | ``geovista`` resources will be downloaded and cached.   |

--- a/src/geovista/geoplotter.py
+++ b/src/geovista/geoplotter.py
@@ -1310,7 +1310,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
         ----------
         points : ArrayLike or PolyData, optional
             Array of xyz points, or the points of the mesh to be rendered.
-            Passed to :meth:`pyvista.core.utilities.helpers.wrap` without any
+            Passed to :func:`pyvista.wrap` without any
             cartographic transformation, i.e. ``0 0 0`` is centre of the globe
             (the plot origin), ``0 0 1`` is the north pole.
         xs : ArrayLike, optional
@@ -1394,7 +1394,7 @@ class GeoPlotterBase:  # numpydoc ignore=PR01
                 raise ValueError(emsg)
 
             if not pv.core.utilities.helpers.is_pyvista_dataset(points):
-                points = pv.core.utilities.helpers.wrap(points)
+                points = pv.wrap(points)
 
             mesh = points
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Drop the unnecessary use of `pyvista.start_xvfb`, which was deprecated and has been removed in 0.48.

---
