### PR TITLE
docs: silence third-party diagnostics for `myst-nb` tutorial generation

### DIFF
--- a/changelog/2255.documentation.rst
+++ b/changelog/2255.documentation.rst
@@ -1,0 +1,3 @@
+Used the `wurlitzer <https://github.com/minrk/wurlitzer>`__ ``IPython`` extension
+to remove third-party diagnostic output from the rendered ``myst-nb`` tutorial.
+(:user:`bjlittle`)

--- a/docs/src/tutorials/region-manifold-extraction.ipynb
+++ b/docs/src/tutorials/region-manifold-extraction.ipynb
@@ -46,9 +46,11 @@
     "import geovista.theme  # noqa: F401\n",
     "\n",
     "# Tip: Change this to \"trame\" for an interactive backend.\n",
-    "pyvista.set_jupyter_backend(\"static\")\n",
+    "_ = pyvista.set_jupyter_backend(\"static\")\n",
     "# Silence the geovista pooch cache manager when downloading resources.\n",
-    "geovista.cache.pooch_mute()"
+    "_ = geovista.cache.pooch_mute()\n",
+    "# Silence thirdy-party diagnostics\n",
+    "%load_ext wurlitzer"
    ]
   },
   {
@@ -690,7 +692,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

For example, removes the following `viskores` diagnostic output polluting the region manifold extraction tutorial notebook:

<img width="567" height="146" alt="image" src="https://github.com/user-attachments/assets/e0c67dae-f746-47b0-96b7-26da0ca29fb3" />

---


