### PR TITLE
WIP: Feature/depth dimension

### DIFF
--- a/changelog/2294.feature.rst
+++ b/changelog/2294.feature.rst
@@ -1,0 +1,8 @@
+Added :meth:`geovista.Transform.from_structured` for building 3D spherical
+:class:`~pyvista.StructuredGrid` meshes from structured longitude/latitude
+arrays and a physical depth dimension. Supports 1D rectilinear, 2D
+curvilinear (including tripolar ocean grids), and terrain-following
+depth arrays. Also adds depth extrusion to
+:meth:`geovista.Transform.from_unstructured`, and fixes a bug in
+:meth:`geovista.Transform.to_structured_grid` where ``zs`` depth values
+were silently replaced by index-based offsets. (:user:`jbusecke`)

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -1074,6 +1074,31 @@ class Transform:  # numpydoc ignore=PR01
         ``lons_vtk`` and ``lats_vtk`` must be in VTK ``(nx, ny)`` layout
         (i.e. the transpose of the NumPy ``(ny, nx)`` convention).
         ``zs`` must be 1D proportional sphere-radius offsets (not metres).
+
+        Parameters
+        ----------
+        lons_vtk : ndarray
+            Longitude array in VTK ``(nx, ny)`` layout (degrees).
+        lats_vtk : ndarray
+            Latitude array in VTK ``(nx, ny)`` layout (degrees).
+        zs : ndarray
+            1D proportional sphere-radius offsets (dimensionless).
+        data : ndarray, optional
+            Data to attach to the grid.
+        name : str, optional
+            Name for the attached data array.
+        crs : CRSLike, optional
+            CRS of the input coordinates.  Only WGS84 is supported.
+        radius : float, optional
+            Sphere radius.  Defaults to :data:`~geovista.common.RADIUS`.
+        zlevel : float, optional
+            Uniform vertical offset added to all ``zs`` values.
+
+        Returns
+        -------
+        StructuredGrid
+            The 3D spherical structured grid.
+
         """
         if crs is None:
             crs = WGS84
@@ -1134,6 +1159,31 @@ class Transform:  # numpydoc ignore=PR01
         Internal helper for :meth:`from_unstructured` when ``depth`` is given.
         Prism (triangular faces) or hexahedral (quad faces) cells are built
         by connecting consecutive depth layers of the surface connectivity.
+
+        Parameters
+        ----------
+        xs : ndarray
+            1D longitude values of the surface nodes (degrees).
+        ys : ndarray
+            1D latitude values of the surface nodes (degrees).
+        connectivity_array : ndarray
+            Face connectivity array, shape ``(nface, nvertices)``.
+        depth : ndarray
+            1D physical depth values in metres, positive = downward.
+        vexag : float
+            Vertical exaggeration multiplier.
+        radius : float or None
+            Sphere radius.  ``None`` uses :data:`~geovista.common.RADIUS`.
+        data : ndarray or None
+            Data to attach to the grid.
+        name : str or None
+            Name for the attached data array.
+
+        Returns
+        -------
+        UnstructuredGrid
+            The 3D volume mesh of prism or hex cells.
+
         """
         if depth.ndim != 1:
             emsg = (
@@ -1156,10 +1206,10 @@ class Transform:  # numpydoc ignore=PR01
         nface, nvertices = connectivity_array.shape
 
         if nvertices == 3:
-            cell_type_id = 13   # VTK_WEDGE (triangular prism)
+            cell_type_id = 13  # VTK_WEDGE (triangular prism)
             pts_per_cell = 6
         elif nvertices == 4:
-            cell_type_id = 12   # VTK_HEXAHEDRON
+            cell_type_id = 12  # VTK_HEXAHEDRON
             pts_per_cell = 8
         else:
             emsg = (
@@ -1171,8 +1221,8 @@ class Transform:  # numpydoc ignore=PR01
         _base_radius = RADIUS if radius is None else abs(float(radius))
         zs = -depth / EARTH_RADIUS_M * float(vexag)
 
-        xyz_unit = to_cartesian(xs, ys, radius=1.0)         # (nnode, 3)
-        r_levels = _base_radius * (1.0 + zs)                # (nz,)
+        xyz_unit = to_cartesian(xs, ys, radius=1.0)  # (nnode, 3)
+        r_levels = _base_radius * (1.0 + zs)  # (nz,)
         xyz_all = (
             r_levels[:, None, None] * xyz_unit[None, :, :]  # (nz,nnode,3)
         ).reshape(-1, 3)
@@ -1182,9 +1232,7 @@ class Transform:  # numpydoc ignore=PR01
         bot_off = ((np.arange(nz - 1) + 1) * nnode)[:, None, None]
         conn = connectivity_array[None, :, :].astype(np.int64)
         cnt = np.full((nz - 1, nface, 1), pts_per_cell, dtype=np.int64)
-        cells = np.concatenate(
-            [cnt, conn + top_off, conn + bot_off], axis=-1
-        ).ravel()
+        cells = np.concatenate([cnt, conn + top_off, conn + bot_off], axis=-1).ravel()
         celltypes = np.full((nz - 1) * nface, cell_type_id, dtype=np.uint8)
 
         ugrid = pv.UnstructuredGrid(cells, celltypes, xyz_all)
@@ -1442,7 +1490,8 @@ class Transform:  # numpydoc ignore=PR01
         # depth extrusion: return 3D UnstructuredGrid instead of surface mesh
         if depth is not None:
             return cls._extrude_to_volume(
-                xs, ys,
+                xs,
+                ys,
                 connectivity_array,
                 np.asarray(depth, dtype=float),
                 float(vexag),
@@ -1702,11 +1751,21 @@ class Transform:  # numpydoc ignore=PR01
         if depth is None:
             if lons.ndim == 1:
                 return cls.from_1d(
-                    lons, lats, data=data, name=name, crs=crs, radius=radius,
+                    lons,
+                    lats,
+                    data=data,
+                    name=name,
+                    crs=crs,
+                    radius=radius,
                     zlevel=zlevel,
                 )
             return cls.from_2d(
-                lons, lats, data=data, name=name, crs=crs, radius=radius,
+                lons,
+                lats,
+                data=data,
+                name=name,
+                crs=crs,
+                radius=radius,
                 zlevel=zlevel,
             )
 
@@ -1716,8 +1775,14 @@ class Transform:  # numpydoc ignore=PR01
         if lons.ndim == 1 and lats.ndim == 1 and zs.ndim == 1:
             # rectilinear: pass 1D arrays; to_structured_grid handles meshgrid
             return cls.to_structured_grid(
-                lons, lats, zs,
-                data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+                lons,
+                lats,
+                zs,
+                data=data,
+                name=name,
+                crs=crs,
+                radius=radius,
+                zlevel=zlevel,
             )
 
         if lons.ndim == 2 and lats.ndim == 2:
@@ -1731,8 +1796,14 @@ class Transform:  # numpydoc ignore=PR01
 
             if zs.ndim == 1:
                 return cls._structured_from_surface_levels(
-                    lons.T, lats.T, zs,
-                    data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+                    lons.T,
+                    lats.T,
+                    zs,
+                    data=data,
+                    name=name,
+                    crs=crs,
+                    radius=radius,
+                    zlevel=zlevel,
                 )
             if zs.ndim == 3 and zs.shape == (zs.shape[0], ny, nx):
                 # terrain-following: depth varies per column (nz, ny, nx)
@@ -1752,8 +1823,14 @@ class Transform:  # numpydoc ignore=PR01
                 raise ValueError(emsg)
 
             return cls.to_structured_grid(
-                lons_v, lats_v, zs_v,
-                data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+                lons_v,
+                lats_v,
+                zs_v,
+                data=data,
+                name=name,
+                crs=crs,
+                radius=radius,
+                zlevel=zlevel,
             )
 
         if lons.ndim == 3 and lons.shape == lats.shape == zs.shape:
@@ -1762,7 +1839,11 @@ class Transform:  # numpydoc ignore=PR01
                 np.ascontiguousarray(lons.T),
                 np.ascontiguousarray(lats.T),
                 np.ascontiguousarray(zs.T),
-                data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+                data=data,
+                name=name,
+                crs=crs,
+                radius=radius,
+                zlevel=zlevel,
             )
 
         emsg = (

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -1693,7 +1693,7 @@ class Transform:  # numpydoc ignore=PR01
         crs: CRSLike | None = None,
         radius: float | None = None,
         vexag: float = 1.0,
-        zlevel: float | None = None,
+        zlevel: int | None = None,
     ) -> pv.PolyData | pv.StructuredGrid:
         """Build a mesh from structured longitude/latitude arrays with optional depth.
 
@@ -1730,7 +1730,7 @@ class Transform:  # numpydoc ignore=PR01
             Vertical exaggeration multiplier.  The depth-to-offset formula is
             ``zs = -depth / radius * vexag``.  Use values > 1 (e.g. 100-600)
             to make vertical structure visible in visualisations.
-        zlevel : float, optional
+        zlevel : int, optional
             Uniform global vertical offset passed through to
             :meth:`to_structured_grid` (scaled by ``ZLEVEL_SCALE``).
 

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -27,6 +27,7 @@ import warnings
 import lazy_loader as lazy
 
 from .common import (
+    EARTH_RADIUS_M,
     GV_FIELD_NAME,
     GV_FIELD_RADIUS,
     GV_FIELD_ZSCALE,
@@ -1051,6 +1052,91 @@ class Transform:  # numpydoc ignore=PR01
             return mesh
 
     @classmethod
+    def _extrude_to_volume(
+        cls,
+        xs: np.ndarray,
+        ys: np.ndarray,
+        connectivity_array: np.ndarray,
+        depth: np.ndarray,
+        vexag: float,
+        radius: float | None,
+        data: np.ndarray | None,
+        name: str | None,
+    ) -> pv.UnstructuredGrid:
+        """Extrude a 2-D unstructured surface into a 3-D volume mesh.
+
+        Internal helper for :meth:`from_unstructured` when ``depth`` is given.
+        Prism (triangular faces) or hexahedral (quad faces) cells are built
+        by connecting consecutive depth layers of the surface connectivity.
+        """
+        if depth.ndim != 1:
+            emsg = (
+                "depth must be 1D with shape (nz,) for from_unstructured; "
+                "terrain-following (per-node) depth is not supported."
+            )
+            raise ValueError(emsg)
+        if depth.size < 2:
+            emsg = "depth must have at least 2 levels for volume extrusion."
+            raise ValueError(emsg)
+        if np.ma.is_masked(connectivity_array):
+            emsg = (
+                "Masked (mixed-face) connectivity is not supported with depth. "
+                "Use uniform triangular or quad face connectivity."
+            )
+            raise ValueError(emsg)
+
+        nnode = xs.size
+        nz = depth.size
+        nface, nvertices = connectivity_array.shape
+
+        if nvertices == 3:
+            cell_type_id = 13   # VTK_WEDGE (triangular prism)
+            pts_per_cell = 6
+        elif nvertices == 4:
+            cell_type_id = 12   # VTK_HEXAHEDRON
+            pts_per_cell = 8
+        else:
+            emsg = (
+                "Only triangular (3) or quad (4) face connectivity is "
+                f"supported for depth extrusion; got {nvertices} vertices."
+            )
+            raise ValueError(emsg)
+
+        _base_radius = RADIUS if radius is None else abs(float(radius))
+        zs = -depth / EARTH_RADIUS_M * float(vexag)
+
+        # Unit-sphere directions scaled per depth level.
+        # to_cartesian(radius=1) gives normalised direction vectors;
+        # r_k = _base_radius*(1+zs[k]) sets the actual sphere-radius.
+        xyz_unit = to_cartesian(xs, ys, radius=1.0)         # (nnode, 3)
+        r_levels = _base_radius * (1.0 + zs)                # (nz,)
+        xyz_all = (
+            r_levels[:, None, None] * xyz_unit[None, :, :]  # (nz,nnode,3)
+        ).reshape(-1, 3)
+
+        # Vectorised cell connectivity: layer k → top (k*nnode) + bottom.
+        top_off = (np.arange(nz - 1) * nnode)[:, None, None]
+        bot_off = ((np.arange(nz - 1) + 1) * nnode)[:, None, None]
+        conn = connectivity_array[None, :, :].astype(np.int64)
+        cnt = np.full((nz - 1, nface, 1), pts_per_cell, dtype=np.int64)
+        cells = np.concatenate(
+            [cnt, conn + top_off, conn + bot_off], axis=-1
+        ).ravel()
+        celltypes = np.full((nz - 1) * nface, cell_type_id, dtype=np.uint8)
+
+        ugrid = pv.UnstructuredGrid(cells, celltypes, xyz_all)
+        to_wkt(ugrid, WGS84)
+
+        if data is not None:
+            data = cls._as_compatible_data(data, ugrid.n_points, ugrid.n_cells)
+            if not name:
+                name = NAME_POINTS if data.size == ugrid.n_points else NAME_CELLS
+            ugrid.field_data[GV_FIELD_NAME] = np.array([name])
+            ugrid[name] = data
+
+        return ugrid
+
+    @classmethod
     def from_unstructured(
         cls,
         xs: ArrayLike,
@@ -1067,7 +1153,9 @@ class Transform:  # numpydoc ignore=PR01
         zlevel: int | None = None,
         zscale: float | None = None,
         clean: bool | None = None,
-    ) -> pv.PolyData:
+        depth: ArrayLike | None = None,
+        vexag: float = 1.0,
+    ) -> pv.PolyData | pv.UnstructuredGrid:
         """Build a mesh from unstructured 1D x-values and y-values.
 
         The `connectivity` defines the topology of faces within the
@@ -1131,11 +1219,23 @@ class Transform:  # numpydoc ignore=PR01
             and/or remove degenerate cells in the resultant mesh. See
             :meth:`pyvista.PolyDataFilters.clean`. Defaults to
             :data:`BRIDGE_CLEAN`.
+        depth : ArrayLike, optional
+            Physical depth values in **metres**, positive = downward.  Must be
+            1D with shape ``(nz,)``; uniform levels applied to all nodes.
+            When provided, the 2D surface is extruded into a 3D volume of
+            prism (triangular faces) or hex (quad faces) cells, and an
+            :class:`~pyvista.UnstructuredGrid` is returned instead of
+            :class:`~pyvista.PolyData`.  Only uniform (non-masked) face
+            connectivity is supported with `depth`.
+        vexag : float, default=1.0
+            Vertical exaggeration multiplier used when `depth` is provided.
+            The depth-to-offset formula is ``zs = -depth / radius * vexag``.
 
         Returns
         -------
-        PolyData
-            The ``(M*N)``-faced spherical mesh.
+        PolyData or UnstructuredGrid
+            The ``(M*N)``-faced spherical surface mesh when `depth` is
+            ``None``; an extruded volume mesh otherwise.
 
         Notes
         -----
@@ -1276,6 +1376,18 @@ class Transform:  # numpydoc ignore=PR01
                 ]
             )
 
+        # depth extrusion: return 3D UnstructuredGrid instead of surface mesh
+        if depth is not None:
+            return cls._extrude_to_volume(
+                xs, ys,
+                connectivity_array,
+                np.asarray(depth, dtype=float),
+                float(vexag),
+                radius,
+                data,
+                name,
+            )
+
         # create the mesh
         mesh = pv.PolyData(geometry, faces=faces)
 
@@ -1379,20 +1491,30 @@ class Transform:  # numpydoc ignore=PR01
         .. versionadded:: 0.6.0
 
         """
-        xs, ys, zs = np.atleast_1d(xs), np.atleast_1d(ys), np.atleast_1d(zs)
+        xs, ys, zs = np.asarray(xs), np.asarray(ys), np.asarray(zs)
 
-        if xs.size < 2 or ys.size < 2 or zs.size < 2:
+        if xs.ndim == 1 and ys.ndim == 1 and zs.ndim == 1:
+            if xs.size < 2 or ys.size < 2 or zs.size < 2:
+                emsg = (
+                    "Require at least two points per dimension to create a "
+                    f"minimal structured grid voxel, got '{xs.size=}', "
+                    f"'{ys.size=}' and '{zs.size=}'."
+                )
+                raise ValueError(emsg)
+            _prebroadcast = False
+        elif xs.ndim == 3 and xs.shape == ys.shape == zs.shape:
+            if any(s < 2 for s in xs.shape):
+                emsg = (
+                    "Require at least two points per dimension to create a "
+                    f"minimal structured grid voxel, got shape {xs.shape}."
+                )
+                raise ValueError(emsg)
+            _prebroadcast = True
+        else:
             emsg = (
-                "Require at least two points per dimension to create a "
-                f"minimal structured grid voxel, got '{xs.size=}', "
-                f"'{ys.size=}' and '{zs.size=}'."
-            )
-            raise ValueError(emsg)
-
-        if xs.ndim != 1 or ys.ndim != 1 or zs.ndim != 1:
-            emsg = (
-                "Require 1D 'xs', 'ys' and 'zs', got "
-                f"'{xs.ndim}D', '{ys.ndim}D' and {zs.ndim}D'."
+                "Require either all-1D arrays (rectilinear) or all-3D arrays "
+                f"of equal shape (pre-broadcast), got shapes "
+                f"{xs.shape}, {ys.shape}, {zs.shape}."
             )
             raise ValueError(emsg)
 
@@ -1418,8 +1540,12 @@ class Transform:  # numpydoc ignore=PR01
         if zlevel:
             zs = zs + zlevel * zscale
 
-        # (M,), (N,), (P,) -> gives shapes (M, N, P)
-        xv, yv, zv = np.meshgrid(xs, ys, zs, indexing="ij")
+        if _prebroadcast:
+            # already in VTK (nx, ny, nz) order; use directly
+            xv, yv, zv = xs, ys, zs
+        else:
+            # (M,), (N,), (P,) -> gives shapes (M, N, P)
+            xv, yv, zv = np.meshgrid(xs, ys, zs, indexing="ij")
         shape = xv.shape
 
         # convert lat/lon to cartesian xyz; zscale=1 because zv already holds
@@ -1444,6 +1570,160 @@ class Transform:  # numpydoc ignore=PR01
             grid[name] = data
 
         return grid
+
+    @classmethod
+    def from_structured(
+        cls,
+        lons: ArrayLike,
+        lats: ArrayLike,
+        /,
+        *,
+        depth: ArrayLike | None = None,
+        data: ArrayLike | None = None,
+        name: str | None = None,
+        crs: CRSLike | None = None,
+        radius: float | None = None,
+        vexag: float = 1.0,
+        zlevel: float | None = None,
+    ) -> pv.PolyData | pv.StructuredGrid:
+        """Build a mesh from structured longitude/latitude arrays with optional depth.
+
+        Accepts 1D rectilinear or 2D/3D curvilinear coordinate arrays and an
+        optional physical depth array.  Without depth, delegates to
+        :meth:`from_1d` or :meth:`from_2d` and returns a surface
+        :class:`~pyvista.PolyData`.  With depth, broadcasts all coordinates to
+        VTK ``(nx, ny, nz)`` order, converts depth in metres to proportional
+        sphere-radius offsets, and delegates to :meth:`to_structured_grid`,
+        returning a :class:`~pyvista.StructuredGrid`.
+
+        Parameters
+        ----------
+        lons : ArrayLike
+            Longitude values (degrees).  Shape ``(nx,)`` for rectilinear,
+            ``(ny, nx)`` for curvilinear, or ``(nz, ny, nx)`` for fully 3D.
+        lats : ArrayLike
+            Latitude values (degrees), same shape convention as `lons`.
+        depth : ArrayLike, optional
+            Physical depth values in **metres**, positive = downward into the
+            Earth.  Shape ``(nz,)`` for uniform levels across the grid, or
+            ``(nz, ny, nx)`` when depths vary spatially (only valid when `lons`
+            and `lats` are 2D or 3D).  When ``None``, returns a surface mesh.
+        data : ArrayLike, optional
+            Data to attach to the mesh, expected in ``(nz, ny, nx)`` order when
+            depth is provided.
+        name : str, optional
+            Name for the attached data array.
+        crs : CRSLike, optional
+            CRS of the input coordinates.  Defaults to ``WGS84``.
+        radius : float, optional
+            Sphere radius in metres.  Defaults to :data:`~geovista.common.RADIUS`.
+        vexag : float, default=1.0
+            Vertical exaggeration multiplier.  The depth-to-offset formula is
+            ``zs = -depth / radius * vexag``.  Use values > 1 (e.g. 100-600)
+            to make vertical structure visible in visualisations.
+        zlevel : float, optional
+            Uniform global vertical offset passed through to
+            :meth:`to_structured_grid` (scaled by ``ZLEVEL_SCALE``).
+
+        Returns
+        -------
+        PolyData or StructuredGrid
+            Surface mesh when `depth` is ``None``; spherical structured grid
+            otherwise.
+
+        Notes
+        -----
+        .. versionadded:: 0.6.0
+
+        """
+        lons = np.asarray(lons)
+        lats = np.asarray(lats)
+
+        if depth is None:
+            if lons.ndim == 1:
+                return cls.from_1d(
+                    lons, lats, data=data, name=name, crs=crs, radius=radius,
+                    zlevel=zlevel,
+                )
+            return cls.from_2d(
+                lons, lats, data=data, name=name, crs=crs, radius=radius,
+                zlevel=zlevel,
+            )
+
+        depth = np.asarray(depth, dtype=float)
+        # Convert metres to dimensionless sphere-radius offsets.
+        # EARTH_RADIUS_M is the physical Earth radius; RADIUS is the normalised
+        # sphere radius (1.0). Dividing by EARTH_RADIUS_M gives the proportion
+        # of the Earth's radius regardless of the normalised RADIUS value.
+        zs = -depth / EARTH_RADIUS_M * float(vexag)
+
+        if lons.ndim == 1 and lats.ndim == 1 and zs.ndim == 1:
+            # rectilinear: pass 1D arrays; to_structured_grid handles meshgrid
+            return cls.to_structured_grid(
+                lons, lats, zs,
+                data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+            )
+
+        if lons.ndim == 2 and lats.ndim == 2:
+            if lons.shape != lats.shape:
+                emsg = (
+                    f"lons and lats must have the same shape, got "
+                    f"{lons.shape} and {lats.shape}."
+                )
+                raise ValueError(emsg)
+            ny, nx = lons.shape
+
+            if zs.ndim == 1:
+                nz = zs.size
+                # curvilinear surface + uniform depth levels:
+                # transpose (ny,nx) → (nx,ny) then broadcast to (nx,ny,nz)
+                lons_v = np.ascontiguousarray(
+                    np.broadcast_to(lons.T[:, :, None], (nx, ny, nz))
+                )
+                lats_v = np.ascontiguousarray(
+                    np.broadcast_to(lats.T[:, :, None], (nx, ny, nz))
+                )
+                zs_v = np.ascontiguousarray(
+                    np.broadcast_to(zs[None, None, :], (nx, ny, nz))
+                )
+            elif zs.ndim == 3 and zs.shape == (zs.shape[0], ny, nx):
+                # terrain-following: depth varies per column (nz, ny, nx)
+                nz = zs.shape[0]
+                lons_v = np.ascontiguousarray(
+                    np.broadcast_to(lons.T[:, :, None], (nx, ny, nz))
+                )
+                lats_v = np.ascontiguousarray(
+                    np.broadcast_to(lats.T[:, :, None], (nx, ny, nz))
+                )
+                zs_v = np.ascontiguousarray(zs.T)
+            else:
+                emsg = (
+                    f"When lons/lats are 2D with shape {lons.shape}, depth must be "
+                    f"1D (nz,) or 3D (nz, ny, nx); got shape {depth.shape}."
+                )
+                raise ValueError(emsg)
+
+            return cls.to_structured_grid(
+                lons_v, lats_v, zs_v,
+                data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+            )
+
+        if lons.ndim == 3 and lons.shape == lats.shape == zs.shape:
+            # fully 3D: (nz, ny, nx) → transpose to (nx, ny, nz)
+            return cls.to_structured_grid(
+                np.ascontiguousarray(lons.T),
+                np.ascontiguousarray(lats.T),
+                np.ascontiguousarray(zs.T),
+                data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
+            )
+
+        emsg = (
+            "Unrecognised coordinate shapes. Expected one of: "
+            "1D+1D+1D (rectilinear), 2D+2D+1D (curvilinear+uniform depth), "
+            "2D+2D+3D (terrain-following), or 3D+3D+3D (fully 3D). "
+            f"Got lons={lons.shape}, lats={lats.shape}, depth={depth.shape}."
+        )
+        raise ValueError(emsg)
 
     def __init__(
         self,

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -1052,6 +1052,72 @@ class Transform:  # numpydoc ignore=PR01
             return mesh
 
     @classmethod
+    def _structured_from_surface_levels(
+        cls,
+        lons_vtk: np.ndarray,
+        lats_vtk: np.ndarray,
+        zs: np.ndarray,
+        *,
+        data: np.ndarray | None = None,
+        name: str | None = None,
+        crs: CRSLike | None = None,
+        radius: float | None = None,
+        zlevel: float | None = None,
+    ) -> pv.StructuredGrid:
+        """Build a StructuredGrid from a 2D surface + 1D depth levels.
+
+        Direction-vector fast path: computes unit-sphere directions once for
+        the 2D surface (nnode points), then scales per depth level.  Avoids
+        materialising three (nx, ny, nz) coordinate arrays (~3x memory saving
+        vs the broadcast path) and skips O(nz) redundant ``to_cartesian`` work.
+
+        ``lons_vtk`` and ``lats_vtk`` must be in VTK ``(nx, ny)`` layout
+        (i.e. the transpose of the NumPy ``(ny, nx)`` convention).
+        ``zs`` must be 1D proportional sphere-radius offsets (not metres).
+        """
+        if crs is None:
+            crs = WGS84
+        if crs != WGS84:
+            emsg = (
+                "Only spatial coordinates with a 'WGS84' CRS are supported"
+                "at the moment."
+            )
+            raise ValueError(emsg)
+
+        _radius = RADIUS if radius is None else abs(float(radius))
+        _zscale = ZLEVEL_SCALE
+        if zlevel:
+            zs = zs + float(zlevel) * _zscale
+
+        nx, ny = lons_vtk.shape
+        nz = zs.size
+
+        # Unit-sphere directions: F-ravel of (nx, ny) → x (i) varies fastest,
+        # matching VTK point ordering i + j*nx + k*nx*ny.
+        xyz_unit = to_cartesian(
+            lons_vtk.ravel("F"), lats_vtk.ravel("F"), radius=1.0, zscale=1
+        )  # (nx*ny, 3)
+
+        r_levels = _radius * (1.0 + zs)  # (nz,)
+        # Broadcast: (nz, nx*ny, 3) reshaped to (nz*nx*ny, 3).
+        # C-ravel gives flat index k*nx*ny + p = i + j*nx + k*nx*ny = VTK index.
+        xyz_all = (r_levels[:, None, None] * xyz_unit[None, :, :]).reshape(-1, 3)
+
+        grid = pv.StructuredGrid()
+        grid.points = xyz_all
+        grid.dimensions = [nx, ny, nz]
+        to_wkt(grid, WGS84)
+
+        if data is not None:
+            data = cls._as_compatible_data(data, grid.n_points, grid.n_cells)
+            if not name:
+                name = NAME_POINTS if data.size == grid.n_points else NAME_CELLS
+            grid.field_data[GV_FIELD_NAME] = np.array([name])
+            grid[name] = data
+
+        return grid
+
+    @classmethod
     def _extrude_to_volume(
         cls,
         xs: np.ndarray,
@@ -1105,9 +1171,6 @@ class Transform:  # numpydoc ignore=PR01
         _base_radius = RADIUS if radius is None else abs(float(radius))
         zs = -depth / EARTH_RADIUS_M * float(vexag)
 
-        # Unit-sphere directions scaled per depth level.
-        # to_cartesian(radius=1) gives normalised direction vectors;
-        # r_k = _base_radius*(1+zs[k]) sets the actual sphere-radius.
         xyz_unit = to_cartesian(xs, ys, radius=1.0)         # (nnode, 3)
         r_levels = _base_radius * (1.0 + zs)                # (nz,)
         xyz_all = (
@@ -1535,13 +1598,10 @@ class Transform:  # numpydoc ignore=PR01
         zscale = ZLEVEL_SCALE if zscale is None else float(zscale)
         zlevel = 0.0 if zlevel is None else float(zlevel)
 
-        # zs values are proportional radius offsets (dimensionless).
-        # A global shift can be layered on top via zlevel * zscale.
         if zlevel:
             zs = zs + zlevel * zscale
 
         if _prebroadcast:
-            # already in VTK (nx, ny, nz) order; use directly
             xv, yv, zv = xs, ys, zs
         else:
             # (M,), (N,), (P,) -> gives shapes (M, N, P)
@@ -1651,10 +1711,6 @@ class Transform:  # numpydoc ignore=PR01
             )
 
         depth = np.asarray(depth, dtype=float)
-        # Convert metres to dimensionless sphere-radius offsets.
-        # EARTH_RADIUS_M is the physical Earth radius; RADIUS is the normalised
-        # sphere radius (1.0). Dividing by EARTH_RADIUS_M gives the proportion
-        # of the Earth's radius regardless of the normalised RADIUS value.
         zs = -depth / EARTH_RADIUS_M * float(vexag)
 
         if lons.ndim == 1 and lats.ndim == 1 and zs.ndim == 1:
@@ -1674,19 +1730,11 @@ class Transform:  # numpydoc ignore=PR01
             ny, nx = lons.shape
 
             if zs.ndim == 1:
-                nz = zs.size
-                # curvilinear surface + uniform depth levels:
-                # transpose (ny,nx) → (nx,ny) then broadcast to (nx,ny,nz)
-                lons_v = np.ascontiguousarray(
-                    np.broadcast_to(lons.T[:, :, None], (nx, ny, nz))
+                return cls._structured_from_surface_levels(
+                    lons.T, lats.T, zs,
+                    data=data, name=name, crs=crs, radius=radius, zlevel=zlevel,
                 )
-                lats_v = np.ascontiguousarray(
-                    np.broadcast_to(lats.T[:, :, None], (nx, ny, nz))
-                )
-                zs_v = np.ascontiguousarray(
-                    np.broadcast_to(zs[None, None, :], (nx, ny, nz))
-                )
-            elif zs.ndim == 3 and zs.shape == (zs.shape[0], ny, nx):
+            if zs.ndim == 3 and zs.shape == (zs.shape[0], ny, nx):
                 # terrain-following: depth varies per column (nz, ny, nx)
                 nz = zs.shape[0]
                 lons_v = np.ascontiguousarray(

--- a/src/geovista/bridge.py
+++ b/src/geovista/bridge.py
@@ -1325,14 +1325,27 @@ class Transform:  # numpydoc ignore=PR01
         Parameters
         ----------
         xs : ArrayLike
-            The 1D array of x-values, in canonical `crs` units, defining the
-            x-axis cell bounds of the grid.
+            The 1D array of longitude values (degrees), defining the
+            x-axis node positions of the grid.
         ys : ArrayLike
-            The 1D array of y-values, in canonical `crs` units, defining the
-            y-axis cell bounds of the grid.
+            The 1D array of latitude values (degrees), defining the
+            y-axis node positions of the grid.
         zs : ArrayLike
-            The 1D array of z-values, in canonical `crs` units, defining the
-            z-axis cell bounds of the grid.
+            The 1D array of vertical-level values, defining the z-axis node
+            positions of the grid.  Each value is a **proportional offset from
+            the base sphere radius** (dimensionless fraction):
+
+            * ``zs = 0.0`` → node lies on the sphere surface (radius = `radius`)
+            * ``zs < 0.0`` → node lies *below* the surface (depth in ocean /
+              subsurface)
+            * ``zs > 0.0`` → node lies *above* the surface (altitude in
+              atmosphere)
+
+            The Cartesian radius for each node is computed as
+            ``r = radius * (1 + zs_val)``.  To convert a physical depth *d*
+            (metres) to a ``zs`` value use
+            ``zs = -d / (earth_radius_m * zscale)``
+            with ``zscale = 1`` (the default used internally by this method).
         data : ArrayLike | None, optional
             Data to be optionally attached to the structured grid cells or points.
             Note that the expected data dimensionality is ``(Z, Y, X)`` order.
@@ -1346,12 +1359,15 @@ class Transform:  # numpydoc ignore=PR01
             Defaults to ``EPSG:4326`` i.e., ``WGS 84``.
         radius : float | None, optional
             The radius of the grid sphere. Defaults to :data:`~geovista.common.RADIUS`.
-        zlevel : int, default=0
-            The z-axis level. Used in combination with the `zscale` to offset the
-            `radius` by a proportional amount i.e., ``radius * zlevel * zscale``.
+        zlevel : float, default=0.0
+            A uniform vertical offset added to *all* ``zs`` values before mesh
+            construction.  The offset is scaled by `zscale` i.e., the effective
+            shift applied to every ``zs`` value is ``zlevel * zscale``.  Use
+            this to lift or sink the entire volume by a fixed amount without
+            modifying the ``zs`` array.
         zscale : float, optional
-            The proportional multiplier for z-axis `zlevel`. Defaults to
-            :data:`~geovista.common.ZLEVEL_SCALE`.
+            The proportional multiplier applied to `zlevel` when computing the
+            global offset.  Defaults to :data:`~geovista.common.ZLEVEL_SCALE`.
 
         Returns
         -------
@@ -1395,17 +1411,19 @@ class Transform:  # numpydoc ignore=PR01
 
         radius = RADIUS if radius is None else abs(float(radius))
         zscale = ZLEVEL_SCALE if zscale is None else float(zscale)
-        zlevel = 0 if zlevel is None else int(zlevel)
+        zlevel = 0.0 if zlevel is None else float(zlevel)
 
-        # TODO @bjlittle: add richer vertical support
-        arc_length = np.radians(np.mean(np.diff(ys)))
-        zs = np.arange(*zs.shape) * arc_length * 0.5 + zlevel * zscale
+        # zs values are proportional radius offsets (dimensionless).
+        # A global shift can be layered on top via zlevel * zscale.
+        if zlevel:
+            zs = zs + zlevel * zscale
 
         # (M,), (N,), (P,) -> gives shapes (M, N, P)
         xv, yv, zv = np.meshgrid(xs, ys, zs, indexing="ij")
         shape = xv.shape
 
-        # convert lat/lon to cartesian xyz
+        # convert lat/lon to cartesian xyz; zscale=1 because zv already holds
+        # the proportional offsets directly.
         xyz = to_cartesian(xv, yv, radius=radius, zlevel=zv, zscale=1)
 
         # create the grid

--- a/src/geovista/common.py
+++ b/src/geovista/common.py
@@ -141,6 +141,12 @@ PERIOD: float = 360.0
 RADIUS: float = 1.0
 """Default radius of a spherical mesh."""
 
+EARTH_RADIUS_M: float = 6.371e6
+"""Mean Earth radius in metres. Used to convert physical depth or altitude
+values (in metres) to the dimensionless proportional offsets required by
+:meth:`~geovista.bridge.Transform.from_structured` and
+:meth:`~geovista.bridge.Transform.from_unstructured`."""
+
 REMESH_JOIN: int = -3
 """Marker for remesh filter cell join point."""
 

--- a/tests/bridge/test_from_structured.py
+++ b/tests/bridge/test_from_structured.py
@@ -91,9 +91,7 @@ class TestFromStructuredShape:
         """Terrain-following depth (nz, ny, nx) with 2-D lon/lat."""
         ny, nx = lons_2d.shape
         nz = len(depth_1d)
-        depth_3d = np.broadcast_to(
-            depth_1d[:, None, None], (nz, ny, nx)
-        ).copy()
+        depth_3d = np.broadcast_to(depth_1d[:, None, None], (nz, ny, nx)).copy()
         result = Transform.from_structured(lons_2d, lats_2d, depth=depth_3d)
         assert isinstance(result, pv.StructuredGrid)
         assert result.n_points == nx * ny * nz
@@ -104,9 +102,7 @@ class TestFromStructuredShape:
         nz = len(depth_1d)
         lons_3d = np.broadcast_to(lons_2d[None], (nz, ny, nx)).copy()
         lats_3d = np.broadcast_to(lats_2d[None], (nz, ny, nx)).copy()
-        depth_3d = np.broadcast_to(
-            depth_1d[:, None, None], (nz, ny, nx)
-        ).copy()
+        depth_3d = np.broadcast_to(depth_1d[:, None, None], (nz, ny, nx)).copy()
         result = Transform.from_structured(lons_3d, lats_3d, depth=depth_3d)
         assert isinstance(result, pv.StructuredGrid)
         assert result.n_points == nx * ny * nz
@@ -139,9 +135,11 @@ class TestFromStructuredDepthSemantics:
         depth = np.array([0.0, 1000.0])
         r1 = Transform.from_structured(lons_1d, lats_1d, depth=depth, vexag=100.0)
         r2 = Transform.from_structured(lons_1d, lats_1d, depth=depth, vexag=200.0)
+
         def _radial_extent(grid: pv.StructuredGrid) -> float:
             norms = np.linalg.norm(grid.points, axis=1)
             return float(norms.max() - norms.min())
+
         np.testing.assert_allclose(
             _radial_extent(r2), 2.0 * _radial_extent(r1), rtol=1e-6
         )

--- a/tests/bridge/test_from_structured.py
+++ b/tests/bridge/test_from_structured.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.Transform.from_structured`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+from geovista.bridge import NAME_CELLS, NAME_POINTS, Transform
+from geovista.common import GV_FIELD_CRS, RADIUS
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def lons_1d():
+    """1-D longitude array (4 points) for rectilinear tests."""
+    return np.linspace(-10.0, 10.0, 4)
+
+
+@pytest.fixture
+def lats_1d():
+    """1-D latitude array (3 points) for rectilinear tests."""
+    return np.linspace(-5.0, 5.0, 3)
+
+
+@pytest.fixture
+def depth_1d():
+    """Depth levels in metres, positive = downward."""
+    return np.array([0.0, 100.0, 500.0, 1000.0])
+
+
+@pytest.fixture
+def lons_2d(lons_1d, lats_1d):
+    """Curvilinear 2-D lon array with shape (ny, nx)."""
+    return np.broadcast_to(lons_1d[None, :], (len(lats_1d), len(lons_1d))).copy()
+
+
+@pytest.fixture
+def lats_2d(lons_1d, lats_1d):
+    """Curvilinear 2-D lat array with shape (ny, nx)."""
+    return np.broadcast_to(lats_1d[:, None], (len(lats_1d), len(lons_1d))).copy()
+
+
+# ── No-depth path: surface mesh delegation ─────────────────────────────────────
+
+
+class TestFromStructuredNoDep:
+    """Without depth, from_structured delegates to from_1d / from_2d."""
+
+    def test_1d_returns_polydata(self, lons_1d, lats_1d):
+        """1-D inputs without depth produce a surface PolyData."""
+        result = Transform.from_structured(lons_1d, lats_1d)
+        assert isinstance(result, pv.PolyData)
+
+    def test_2d_returns_polydata(self, lons_2d, lats_2d):
+        """2-D curvilinear inputs without depth produce a surface PolyData."""
+        result = Transform.from_structured(lons_2d, lats_2d)
+        assert isinstance(result, pv.PolyData)
+
+
+# ── With depth: StructuredGrid shape ──────────────────────────────────────────
+
+
+class TestFromStructuredShape:
+    """Verify StructuredGrid dimensions for all broadcasting cases."""
+
+    def test_1d_rectilinear(self, lons_1d, lats_1d, depth_1d):
+        """1-D lon/lat/depth produces (nx*ny*nz) points and correct cells."""
+        nx, ny, nz = len(lons_1d), len(lats_1d), len(depth_1d)
+        result = Transform.from_structured(lons_1d, lats_1d, depth=depth_1d)
+        assert isinstance(result, pv.StructuredGrid)
+        assert result.n_points == nx * ny * nz
+        assert result.n_cells == (nx - 1) * (ny - 1) * (nz - 1)
+
+    def test_2d_curvilinear_1d_depth(self, lons_2d, lats_2d, depth_1d):
+        """2-D curvilinear lon/lat with 1-D depth produces correct grid."""
+        ny, nx = lons_2d.shape
+        nz = len(depth_1d)
+        result = Transform.from_structured(lons_2d, lats_2d, depth=depth_1d)
+        assert isinstance(result, pv.StructuredGrid)
+        assert result.n_points == nx * ny * nz
+        assert result.n_cells == (nx - 1) * (ny - 1) * (nz - 1)
+
+    def test_2d_curvilinear_3d_depth(self, lons_2d, lats_2d, depth_1d):
+        """Terrain-following depth (nz, ny, nx) with 2-D lon/lat."""
+        ny, nx = lons_2d.shape
+        nz = len(depth_1d)
+        depth_3d = np.broadcast_to(
+            depth_1d[:, None, None], (nz, ny, nx)
+        ).copy()
+        result = Transform.from_structured(lons_2d, lats_2d, depth=depth_3d)
+        assert isinstance(result, pv.StructuredGrid)
+        assert result.n_points == nx * ny * nz
+
+    def test_3d_fully_curvilinear(self, lons_2d, lats_2d, depth_1d):
+        """Fully 3-D inputs (nz, ny, nx) for all arrays."""
+        ny, nx = lons_2d.shape
+        nz = len(depth_1d)
+        lons_3d = np.broadcast_to(lons_2d[None], (nz, ny, nx)).copy()
+        lats_3d = np.broadcast_to(lats_2d[None], (nz, ny, nx)).copy()
+        depth_3d = np.broadcast_to(
+            depth_1d[:, None, None], (nz, ny, nx)
+        ).copy()
+        result = Transform.from_structured(lons_3d, lats_3d, depth=depth_3d)
+        assert isinstance(result, pv.StructuredGrid)
+        assert result.n_points == nx * ny * nz
+
+
+# ── Depth semantics ────────────────────────────────────────────────────────────
+
+
+class TestFromStructuredDepthSemantics:
+    """Verify that depth is placed below the sphere surface."""
+
+    def test_positive_depth_below_surface(self, lons_1d, lats_1d):
+        """Positive depth values must produce radii strictly less than RADIUS."""
+        depth = np.array([100.0, 1000.0])
+        result = Transform.from_structured(lons_1d, lats_1d, depth=depth, vexag=1.0)
+        radii = np.linalg.norm(result.points, axis=1)
+        assert np.all(radii < RADIUS)
+
+    def test_zero_depth_on_surface(self, lons_1d, lats_1d):
+        """Depth=0 nodes must lie exactly on the sphere surface."""
+        depth = np.array([0.0, 0.0001])
+        result = Transform.from_structured(lons_1d, lats_1d, depth=depth, vexag=1.0)
+        nxy = len(lons_1d) * len(lats_1d)
+        surface_pts = result.points[:nxy]
+        radii = np.linalg.norm(surface_pts, axis=1)
+        np.testing.assert_allclose(radii, RADIUS, rtol=1e-6)
+
+    def test_vexag_scales_depth_extent(self, lons_1d, lats_1d):
+        """Doubling vexag must double the radial depth extent."""
+        depth = np.array([0.0, 1000.0])
+        r1 = Transform.from_structured(lons_1d, lats_1d, depth=depth, vexag=100.0)
+        r2 = Transform.from_structured(lons_1d, lats_1d, depth=depth, vexag=200.0)
+        def _radial_extent(grid: pv.StructuredGrid) -> float:
+            norms = np.linalg.norm(grid.points, axis=1)
+            return float(norms.max() - norms.min())
+        np.testing.assert_allclose(
+            _radial_extent(r2), 2.0 * _radial_extent(r1), rtol=1e-6
+        )
+
+    def test_crs_attached(self, lons_1d, lats_1d, depth_1d, wgs84_wkt):
+        """WGS84 CRS metadata must be attached to the output grid."""
+        result = Transform.from_structured(lons_1d, lats_1d, depth=depth_1d)
+        assert result[GV_FIELD_CRS] == wgs84_wkt
+
+
+# ── Data attachment ────────────────────────────────────────────────────────────
+
+
+class TestFromStructuredData:
+    """Verify data arrays are correctly attached to the grid."""
+
+    def test_cell_data_attached(self, lons_1d, lats_1d, depth_1d):
+        """Named cell data is stored and retrievable from the grid."""
+        nx, ny, nz = len(lons_1d), len(lats_1d), len(depth_1d)
+        n_cells = (nx - 1) * (ny - 1) * (nz - 1)
+        data = np.arange(n_cells, dtype=float).reshape(nz - 1, ny - 1, nx - 1)
+        result = Transform.from_structured(
+            lons_1d, lats_1d, depth=depth_1d, data=data, name="temp"
+        )
+        assert "temp" in result.array_names
+        assert result["temp"].size == n_cells
+
+    def test_point_data_attached(self, lons_1d, lats_1d, depth_1d):
+        """Point data sized n_points is attached with the default name."""
+        nx, ny, nz = len(lons_1d), len(lats_1d), len(depth_1d)
+        n_pts = nx * ny * nz
+        result = Transform.from_structured(
+            lons_1d, lats_1d, depth=depth_1d, data=np.ones(n_pts)
+        )
+        assert result[NAME_POINTS].size == n_pts
+
+    def test_default_name_cells(self, lons_1d, lats_1d, depth_1d):
+        """Cell data without an explicit name gets the NAME_CELLS default."""
+        nx, ny, nz = len(lons_1d), len(lats_1d), len(depth_1d)
+        n_cells = (nx - 1) * (ny - 1) * (nz - 1)
+        result = Transform.from_structured(
+            lons_1d, lats_1d, depth=depth_1d, data=np.zeros(n_cells)
+        )
+        assert NAME_CELLS in result.array_names
+
+
+# ── Error handling ────────────────────────────────────────────────────────────
+
+
+class TestFromStructuredErrors:
+    """Verify that invalid inputs raise clear errors."""
+
+    def test_mismatched_2d_shapes_raises(self, lons_2d, depth_1d):
+        """Mismatched 2-D lon/lat shapes must raise ValueError."""
+        bad_lats = np.zeros((lons_2d.shape[0] + 1, lons_2d.shape[1]))
+        with pytest.raises(ValueError, match="same shape"):
+            Transform.from_structured(lons_2d, bad_lats, depth=depth_1d)
+
+    def test_2d_lons_bad_depth_ndim_raises(self, lons_2d, lats_2d):
+        """2-D depth paired with 2-D lon/lat must raise ValueError."""
+        bad_depth = np.ones((2, 2))
+        with pytest.raises(ValueError, match="depth must be"):
+            Transform.from_structured(lons_2d, lats_2d, depth=bad_depth)
+
+    def test_incompatible_shapes_raises(self, lons_2d, lats_2d):
+        """3-D depth with incompatible spatial shape must raise ValueError."""
+        wrong_depth = np.ones((3, lons_2d.shape[0] + 1, lons_2d.shape[1]))
+        with pytest.raises(ValueError, match="depth must be"):
+            Transform.from_structured(lons_2d, lats_2d, depth=wrong_depth)
+
+    def test_unrecognised_ndim_raises(self):
+        """4-D coordinate arrays must raise ValueError."""
+        lons = np.zeros((2, 2, 2, 2))
+        lats = np.zeros((2, 2, 2, 2))
+        depth = np.array([0.0, 100.0])
+        with pytest.raises(ValueError, match="Unrecognised"):
+            Transform.from_structured(lons, lats, depth=depth)

--- a/tests/bridge/test_from_unstructured_depth.py
+++ b/tests/bridge/test_from_unstructured_depth.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Depth-extrusion tests for :meth:`geovista.Transform.from_unstructured`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+from geovista.bridge import NAME_CELLS, NAME_POINTS, Transform
+from geovista.common import GV_FIELD_CRS, RADIUS
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def triangle_mesh():
+    """Minimal triangular mesh: 4 nodes, 2 faces."""
+    lons = np.array([0.0, 1.0, 0.0, 1.0])
+    lats = np.array([0.0, 0.0, 1.0, 1.0])
+    conn = np.array([[0, 1, 2], [1, 3, 2]])
+    return lons, lats, conn
+
+
+@pytest.fixture
+def quad_mesh():
+    """Minimal quad mesh: 4 nodes, 1 face."""
+    lons = np.array([0.0, 1.0, 1.0, 0.0])
+    lats = np.array([0.0, 0.0, 1.0, 1.0])
+    conn = np.array([[0, 1, 2, 3]])
+    return lons, lats, conn
+
+
+@pytest.fixture
+def depth_levels():
+    """Three depth levels → two extruded layers."""
+    return np.array([0.0, 100.0, 500.0])
+
+
+# ── No-depth: existing surface behaviour unchanged ────────────────────────────
+
+
+class TestFromUnstructuredNoDepth:
+    """Without depth, existing PolyData behaviour is unchanged."""
+
+    def test_returns_polydata(self, triangle_mesh):
+        """Triangular mesh without depth returns PolyData."""
+        lons, lats, conn = triangle_mesh
+        result = Transform.from_unstructured(lons, lats, connectivity=conn)
+        assert isinstance(result, pv.PolyData)
+
+    def test_quad_returns_polydata(self, quad_mesh):
+        """Quad mesh without depth returns PolyData."""
+        lons, lats, conn = quad_mesh
+        result = Transform.from_unstructured(lons, lats, connectivity=conn)
+        assert isinstance(result, pv.PolyData)
+
+
+# ── With depth: UnstructuredGrid shape ───────────────────────────────────────
+
+
+class TestFromUnstructuredDepthShape:
+    """Verify cell and point counts for extruded meshes."""
+
+    def test_triangle_cell_count(self, triangle_mesh, depth_levels):
+        """Cell count equals nface * (nz - 1) for triangular extrusion."""
+        lons, lats, conn = triangle_mesh
+        nface = conn.shape[0]
+        nz = len(depth_levels)
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert isinstance(result, pv.UnstructuredGrid)
+        assert result.n_cells == nface * (nz - 1)
+
+    def test_triangle_point_count(self, triangle_mesh, depth_levels):
+        """Point count equals nnode * nz for triangular extrusion."""
+        lons, lats, conn = triangle_mesh
+        nnode = len(lons)
+        nz = len(depth_levels)
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert result.n_points == nnode * nz
+
+    def test_quad_cell_count(self, quad_mesh, depth_levels):
+        """Cell count equals nface * (nz - 1) for quad extrusion."""
+        lons, lats, conn = quad_mesh
+        nface = conn.shape[0]
+        nz = len(depth_levels)
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert result.n_cells == nface * (nz - 1)
+
+    def test_quad_point_count(self, quad_mesh, depth_levels):
+        """Point count equals nnode * nz for quad extrusion."""
+        lons, lats, conn = quad_mesh
+        nnode = len(lons)
+        nz = len(depth_levels)
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert result.n_points == nnode * nz
+
+    def test_returns_unstructured_grid(self, triangle_mesh, depth_levels):
+        """Depth extrusion must return an UnstructuredGrid."""
+        lons, lats, conn = triangle_mesh
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert isinstance(result, pv.UnstructuredGrid)
+
+
+# ── Cell types ────────────────────────────────────────────────────────────────
+
+
+class TestFromUnstructuredCellTypes:
+    """Verify correct VTK cell types are created."""
+
+    def test_triangle_produces_wedge_cells(self, triangle_mesh, depth_levels):
+        """Triangular faces must produce VTK_WEDGE (type 13) cells."""
+        lons, lats, conn = triangle_mesh
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert np.all(result.celltypes == 13)
+
+    def test_quad_produces_hex_cells(self, quad_mesh, depth_levels):
+        """Quad faces must produce VTK_HEXAHEDRON (type 12) cells."""
+        lons, lats, conn = quad_mesh
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert np.all(result.celltypes == 12)
+
+
+# ── Depth semantics ───────────────────────────────────────────────────────────
+
+
+class TestFromUnstructuredDepthSemantics:
+    """Verify depth values map nodes to the correct sphere radius."""
+
+    def test_positive_depth_below_surface(self, triangle_mesh):
+        """All nodes at positive depth must have radius < RADIUS."""
+        lons, lats, conn = triangle_mesh
+        depth = np.array([100.0, 1000.0])
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth, vexag=1.0
+        )
+        radii = np.linalg.norm(result.points, axis=1)
+        assert np.all(radii < RADIUS)
+
+    def test_zero_depth_on_surface(self, triangle_mesh):
+        """Nodes at depth=0 must lie exactly on the sphere surface."""
+        lons, lats, conn = triangle_mesh
+        depth = np.array([0.0, 100.0])
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth, vexag=1.0
+        )
+        nnode = len(lons)
+        surface_radii = np.linalg.norm(result.points[:nnode], axis=1)
+        np.testing.assert_allclose(surface_radii, RADIUS, rtol=1e-6)
+
+    def test_crs_attached(self, triangle_mesh, depth_levels, wgs84_wkt):
+        """WGS84 CRS metadata must be attached to the extruded grid."""
+        lons, lats, conn = triangle_mesh
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels
+        )
+        assert result[GV_FIELD_CRS] == wgs84_wkt
+
+
+# ── Data attachment ───────────────────────────────────────────────────────────
+
+
+class TestFromUnstructuredDepthData:
+    """Verify data is correctly attached to extruded meshes."""
+
+    def test_cell_data_attached(self, triangle_mesh, depth_levels):
+        """Named cell data sized n_cells is stored and retrievable."""
+        lons, lats, conn = triangle_mesh
+        nface = conn.shape[0]
+        nz = len(depth_levels)
+        n_cells = nface * (nz - 1)
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels,
+            data=np.arange(n_cells, dtype=float), name="sal",
+        )
+        assert "sal" in result.array_names
+        assert result["sal"].size == n_cells
+
+    def test_point_data_attached(self, triangle_mesh, depth_levels):
+        """Point data sized n_points is attached with the default name."""
+        lons, lats, conn = triangle_mesh
+        nnode = len(lons)
+        nz = len(depth_levels)
+        n_pts = nnode * nz
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels,
+            data=np.ones(n_pts),
+        )
+        assert result[NAME_POINTS].size == n_pts
+
+    def test_default_name_cells(self, triangle_mesh, depth_levels):
+        """Cell data without a name gets the NAME_CELLS default."""
+        lons, lats, conn = triangle_mesh
+        nface, nz = conn.shape[0], len(depth_levels)
+        result = Transform.from_unstructured(
+            lons, lats, connectivity=conn, depth=depth_levels,
+            data=np.zeros(nface * (nz - 1)),
+        )
+        assert NAME_CELLS in result.array_names
+
+
+# ── Error handling ────────────────────────────────────────────────────────────
+
+
+class TestFromUnstructuredDepthErrors:
+    """Verify invalid depth inputs raise clear errors."""
+
+    def test_2d_depth_raises(self, triangle_mesh):
+        """2-D depth array must raise ValueError."""
+        lons, lats, conn = triangle_mesh
+        with pytest.raises(ValueError, match="1D"):
+            Transform.from_unstructured(
+                lons, lats, connectivity=conn, depth=np.ones((2, 3))
+            )
+
+    def test_single_depth_level_raises(self, triangle_mesh):
+        """A depth array with fewer than 2 levels must raise ValueError."""
+        lons, lats, conn = triangle_mesh
+        with pytest.raises(ValueError, match="at least 2"):
+            Transform.from_unstructured(
+                lons, lats, connectivity=conn, depth=np.array([100.0])
+            )
+
+    def test_masked_connectivity_raises(self, depth_levels):
+        """Masked (mixed-face) connectivity with depth must raise ValueError."""
+        lons = np.array([0.0, 1.0, 0.0, 1.0])
+        lats = np.array([0.0, 0.0, 1.0, 1.0])
+        conn = np.ma.array(
+            [[0, 1, 2, -1], [1, 3, 2, -1]],
+            mask=[[0, 0, 0, 1], [0, 0, 0, 1]],
+        )
+        with pytest.raises(ValueError, match=r"[Mm]asked"):
+            Transform.from_unstructured(
+                lons, lats, connectivity=conn, depth=depth_levels
+            )
+
+    def test_pentagon_connectivity_raises(self, depth_levels):
+        """Pentagon faces (5 vertices) with depth must raise ValueError."""
+        lons = np.array([0.0, 1.0, 2.0, 1.0, 0.5])
+        lats = np.array([0.0, 0.0, 1.0, 2.0, 1.0])
+        conn = np.array([[0, 1, 2, 3, 4]])
+        with pytest.raises(ValueError, match="triangular"):
+            Transform.from_unstructured(
+                lons, lats, connectivity=conn, depth=depth_levels
+            )

--- a/tests/bridge/test_from_unstructured_depth.py
+++ b/tests/bridge/test_from_unstructured_depth.py
@@ -188,8 +188,12 @@ class TestFromUnstructuredDepthData:
         nz = len(depth_levels)
         n_cells = nface * (nz - 1)
         result = Transform.from_unstructured(
-            lons, lats, connectivity=conn, depth=depth_levels,
-            data=np.arange(n_cells, dtype=float), name="sal",
+            lons,
+            lats,
+            connectivity=conn,
+            depth=depth_levels,
+            data=np.arange(n_cells, dtype=float),
+            name="sal",
         )
         assert "sal" in result.array_names
         assert result["sal"].size == n_cells
@@ -201,7 +205,10 @@ class TestFromUnstructuredDepthData:
         nz = len(depth_levels)
         n_pts = nnode * nz
         result = Transform.from_unstructured(
-            lons, lats, connectivity=conn, depth=depth_levels,
+            lons,
+            lats,
+            connectivity=conn,
+            depth=depth_levels,
             data=np.ones(n_pts),
         )
         assert result[NAME_POINTS].size == n_pts
@@ -211,7 +218,10 @@ class TestFromUnstructuredDepthData:
         lons, lats, conn = triangle_mesh
         nface, nz = conn.shape[0], len(depth_levels)
         result = Transform.from_unstructured(
-            lons, lats, connectivity=conn, depth=depth_levels,
+            lons,
+            lats,
+            connectivity=conn,
+            depth=depth_levels,
             data=np.zeros(nface * (nz - 1)),
         )
         assert NAME_CELLS in result.array_names

--- a/tests/bridge/test_to_structured_grid.py
+++ b/tests/bridge/test_to_structured_grid.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Unit-tests for :meth:`geovista.Transform.to_structured_grid`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+from geovista.bridge import NAME_CELLS, NAME_POINTS, Transform
+from geovista.common import GV_FIELD_CRS, RADIUS
+
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def simple_inputs():
+    """Minimal lon/lat/depth arrays: 3×2×3 points → 2×1×2 cells."""
+    xs = np.linspace(-10.0, 10.0, 4)     # 4 lon points  → 3 lon cells
+    ys = np.linspace(-5.0, 5.0, 3)       # 3 lat points  → 2 lat cells
+    zs = np.array([0.0, -0.01, -0.02])   # 3 depth points → 2 depth cells
+    return xs, ys, zs
+
+
+# ── Return type and basic shape ────────────────────────────────────────────────
+
+
+class TestToStructuredGridBasics:
+    """Verify basic output type and grid dimensions."""
+
+    def test_returns_structured_grid(self, simple_inputs):
+        xs, ys, zs = simple_inputs
+        result = Transform.to_structured_grid(xs, ys, zs)
+        assert isinstance(result, pv.StructuredGrid)
+
+    def test_crs_attached(self, simple_inputs, wgs84_wkt):
+        xs, ys, zs = simple_inputs
+        result = Transform.to_structured_grid(xs, ys, zs)
+        assert result[GV_FIELD_CRS] == wgs84_wkt
+
+    def test_point_count(self, simple_inputs):
+        xs, ys, zs = simple_inputs
+        result = Transform.to_structured_grid(xs, ys, zs)
+        assert result.n_points == len(xs) * len(ys) * len(zs)
+
+    def test_cell_count(self, simple_inputs):
+        xs, ys, zs = simple_inputs
+        result = Transform.to_structured_grid(xs, ys, zs)
+        expected = (len(xs) - 1) * (len(ys) - 1) * (len(zs) - 1)
+        assert result.n_cells == expected
+
+    def test_minimal_two_points_per_dim(self):
+        """Two points per dimension produces exactly one cell."""
+        xs = np.array([0.0, 1.0])
+        ys = np.array([0.0, 1.0])
+        zs = np.array([0.0, -0.01])
+        result = Transform.to_structured_grid(xs, ys, zs)
+        assert result.n_cells == 1
+
+
+# ── Depth-to-radius mapping ────────────────────────────────────────────────────
+
+
+class TestDepthRadiusMapping:
+    """Verify that zs values map correctly to sphere radii.
+
+    The proportional model is: r = radius * (1 + zs_val)
+    - zs_val = 0.0  → r = RADIUS  (on the surface)
+    - zs_val < 0.0  → r < RADIUS  (below the surface, i.e. depth)
+    - zs_val > 0.0  → r > RADIUS  (above the surface, i.e. altitude)
+    """
+
+    def test_negative_zs_reduce_radius(self):
+        """Depth levels (zs < 0) must produce radii smaller than RADIUS."""
+        xs = np.array([-5.0, 0.0, 5.0])
+        ys = np.array([-5.0, 0.0, 5.0])
+        zs = np.array([-0.01, -0.02])
+        result = Transform.to_structured_grid(xs, ys, zs)
+        radii = np.linalg.norm(result.points, axis=1)
+        assert np.all(radii < RADIUS)
+
+    def test_positive_zs_increase_radius(self):
+        """Altitude levels (zs > 0) must produce radii larger than RADIUS."""
+        xs = np.array([-5.0, 0.0, 5.0])
+        ys = np.array([-5.0, 0.0, 5.0])
+        zs = np.array([0.01, 0.02])
+        result = Transform.to_structured_grid(xs, ys, zs)
+        radii = np.linalg.norm(result.points, axis=1)
+        assert np.all(radii > RADIUS)
+
+    def test_zs_zero_gives_surface_radius(self):
+        """Points at zs=0 should lie exactly on the base sphere.
+
+        All points on the same spherical shell have identical Euclidean
+        distance from the origin, so we verify the unique radius values
+        rather than relying on a particular point ordering.
+        """
+        xs = np.array([-5.0, 0.0, 5.0])
+        ys = np.array([-5.0, 0.0, 5.0])
+        zs = np.array([0.0, -0.01])
+        result = Transform.to_structured_grid(xs, ys, zs)
+        radii = np.linalg.norm(result.points, axis=1)
+        # Expect exactly two shells: RADIUS and RADIUS*0.99
+        unique_radii = np.sort(np.unique(radii.round(8)))[::-1]
+        np.testing.assert_allclose(unique_radii[0], RADIUS, rtol=1e-6)
+
+    def test_zs_values_are_honored_not_replaced(self):
+        """REGRESSION: zs must be used as-is, not replaced by np.arange.
+
+        If the bug where zs is replaced with np.arange is present, two grids
+        with the same *shape* but different *values* will produce identical
+        radii.  After the fix, deeper zs must yield strictly smaller radii.
+        """
+        xs = np.array([0.0, 1.0])
+        ys = np.array([0.0, 1.0])
+
+        grid_1pct = Transform.to_structured_grid(xs, ys, np.array([0.0, -0.01]))
+        grid_10pct = Transform.to_structured_grid(xs, ys, np.array([0.0, -0.10]))
+
+        min_r_1pct = np.linalg.norm(grid_1pct.points, axis=1).min()
+        min_r_10pct = np.linalg.norm(grid_10pct.points, axis=1).min()
+
+        assert min_r_10pct < min_r_1pct, (
+            "Deeper zs must produce smaller radii. "
+            "If both grids give the same min radius the bug is still present."
+        )
+
+    def test_absolute_radius_values(self):
+        """The absolute radius at each depth level matches the analytic formula.
+
+        All points on one spherical shell share the same Euclidean radius, so we
+        compare sorted unique radii to the sorted expected values.
+        """
+        xs = np.array([0.0, 1.0])
+        ys = np.array([0.0, 1.0])
+        depths = np.array([0.0, -0.01, -0.05, -0.10])
+        result = Transform.to_structured_grid(xs, ys, depths)
+
+        unique_radii = np.sort(np.unique(np.linalg.norm(result.points, axis=1).round(8)))
+        expected = np.sort([RADIUS * (1.0 + d) for d in depths])
+        np.testing.assert_allclose(unique_radii, expected, rtol=1e-5)
+
+    def test_monotonically_decreasing_radii_with_depth(self):
+        """Monotonically decreasing zs must produce monotonically decreasing unique radii.
+
+        Each distinct zs value maps to a unique spherical shell; checking the
+        sorted unique radii avoids any dependency on PyVista's internal point
+        ordering.
+        """
+        xs = np.array([0.0, 1.0])
+        ys = np.array([0.0, 1.0])
+        zs = np.array([0.0, -0.01, -0.05, -0.10])
+        result = Transform.to_structured_grid(xs, ys, zs)
+
+        unique_radii = np.sort(
+            np.unique(np.linalg.norm(result.points, axis=1).round(8))
+        )[::-1]  # largest first = surface first
+        assert len(unique_radii) == len(zs), "Each zs value must produce a distinct shell"
+        np.testing.assert_array_less(
+            np.diff(unique_radii),
+            0,
+            err_msg="Unique radii must decrease monotonically with depth",
+        )
+
+
+# ── Input validation ───────────────────────────────────────────────────────────
+
+
+class TestToStructuredGridValidation:
+    """Verify that invalid inputs raise informative errors."""
+
+    @pytest.mark.parametrize(
+        ("xs", "ys", "zs"),
+        [
+            (np.array([0.0]), np.array([0.0, 1.0]), np.array([0.0, 1.0])),
+            (np.array([0.0, 1.0]), np.array([0.0]), np.array([0.0, 1.0])),
+            (np.array([0.0, 1.0]), np.array([0.0, 1.0]), np.array([0.0])),
+        ],
+        ids=["too-few-xs", "too-few-ys", "too-few-zs"],
+    )
+    def test_raises_on_too_few_points(self, xs, ys, zs):
+        with pytest.raises(ValueError, match="at least two points"):
+            Transform.to_structured_grid(xs, ys, zs)
+
+    @pytest.mark.parametrize(
+        ("xs", "ys", "zs"),
+        [
+            (np.array([[0.0, 1.0]]), np.array([0.0, 1.0]), np.array([0.0, 1.0])),
+            (np.array([0.0, 1.0]), np.array([[0.0, 1.0]]), np.array([0.0, 1.0])),
+            (np.array([0.0, 1.0]), np.array([0.0, 1.0]), np.array([[0.0, 1.0]])),
+        ],
+        ids=["2d-xs", "2d-ys", "2d-zs"],
+    )
+    def test_raises_on_non_1d_inputs(self, xs, ys, zs):
+        with pytest.raises(ValueError, match="Require 1D"):
+            Transform.to_structured_grid(xs, ys, zs)
+
+    def test_raises_on_non_wgs84_crs(self):
+        """Non-WGS84 CRS is not yet supported and should raise."""
+        xs = np.linspace(-180.0, 180.0, 4)
+        ys = np.linspace(-90.0, 90.0, 3)
+        zs = np.array([0.0, -0.01])
+        with pytest.raises(ValueError, match="WGS84"):
+            Transform.to_structured_grid(xs, ys, zs, crs="+proj=eqc")
+
+
+# ── Data attachment ────────────────────────────────────────────────────────────
+
+
+class TestToStructuredGridData:
+    """Verify data can be attached to cells or points."""
+
+    def test_attach_cell_data(self, simple_inputs):
+        xs, ys, zs = simple_inputs
+        ref = Transform.to_structured_grid(xs, ys, zs)
+        data = np.arange(ref.n_cells, dtype=float)
+        result = Transform.to_structured_grid(xs, ys, zs, data=data)
+        assert NAME_CELLS in result.cell_data
+        np.testing.assert_array_equal(result[NAME_CELLS], data)
+
+    def test_attach_point_data(self, simple_inputs):
+        xs, ys, zs = simple_inputs
+        ref = Transform.to_structured_grid(xs, ys, zs)
+        data = np.arange(ref.n_points, dtype=float)
+        result = Transform.to_structured_grid(xs, ys, zs, data=data)
+        assert NAME_POINTS in result.point_data
+        np.testing.assert_array_equal(result[NAME_POINTS], data)
+
+    def test_named_data(self, simple_inputs):
+        xs, ys, zs = simple_inputs
+        ref = Transform.to_structured_grid(xs, ys, zs)
+        data = np.arange(ref.n_cells, dtype=float)
+        result = Transform.to_structured_grid(
+            xs, ys, zs, data=data, name="temperature"
+        )
+        assert "temperature" in result.cell_data
+
+
+# ── Custom radius ──────────────────────────────────────────────────────────────
+
+
+class TestToStructuredGridRadius:
+    """Verify that a custom radius is honoured."""
+
+    def test_custom_radius_scales_output(self):
+        """Providing radius=2.0 should scale all point distances from origin."""
+        xs = np.array([-5.0, 0.0, 5.0])
+        ys = np.array([-5.0, 0.0, 5.0])
+        zs = np.array([0.0, -0.01])
+        r = 2.0
+        result = Transform.to_structured_grid(xs, ys, zs, radius=r)
+
+        unique_radii = np.sort(
+            np.unique(np.linalg.norm(result.points, axis=1).round(8))
+        )[::-1]
+        # Surface shell: r * (1 + 0) = 2.0
+        np.testing.assert_allclose(unique_radii[0], r, rtol=1e-6)
+        # Depth shell: r * (1 - 0.01) = 1.98
+        np.testing.assert_allclose(unique_radii[1], r * (1.0 - 0.01), rtol=1e-5)

--- a/tests/bridge/test_to_structured_grid.py
+++ b/tests/bridge/test_to_structured_grid.py
@@ -14,16 +14,15 @@ import pyvista as pv
 from geovista.bridge import NAME_CELLS, NAME_POINTS, Transform
 from geovista.common import GV_FIELD_CRS, RADIUS
 
-
 # ── Shared fixtures ────────────────────────────────────────────────────────────
 
 
 @pytest.fixture
 def simple_inputs():
-    """Minimal lon/lat/depth arrays: 3×2×3 points → 2×1×2 cells."""
-    xs = np.linspace(-10.0, 10.0, 4)     # 4 lon points  → 3 lon cells
-    ys = np.linspace(-5.0, 5.0, 3)       # 3 lat points  → 2 lat cells
-    zs = np.array([0.0, -0.01, -0.02])   # 3 depth points → 2 depth cells
+    """Minimal lon/lat/depth arrays: 4x3x3 points giving 3x2x2 cells."""
+    xs = np.linspace(-10.0, 10.0, 4)     # 4 lon points  -> 3 lon cells
+    ys = np.linspace(-5.0, 5.0, 3)       # 3 lat points  -> 2 lat cells
+    zs = np.array([0.0, -0.01, -0.02])   # 3 depth points -> 2 depth cells
     return xs, ys, zs
 
 
@@ -34,21 +33,25 @@ class TestToStructuredGridBasics:
     """Verify basic output type and grid dimensions."""
 
     def test_returns_structured_grid(self, simple_inputs):
+        """Return type must be StructuredGrid."""
         xs, ys, zs = simple_inputs
         result = Transform.to_structured_grid(xs, ys, zs)
         assert isinstance(result, pv.StructuredGrid)
 
     def test_crs_attached(self, simple_inputs, wgs84_wkt):
+        """WGS84 CRS metadata must be attached to the output grid."""
         xs, ys, zs = simple_inputs
         result = Transform.to_structured_grid(xs, ys, zs)
         assert result[GV_FIELD_CRS] == wgs84_wkt
 
     def test_point_count(self, simple_inputs):
+        """Point count must equal len(xs) * len(ys) * len(zs)."""
         xs, ys, zs = simple_inputs
         result = Transform.to_structured_grid(xs, ys, zs)
         assert result.n_points == len(xs) * len(ys) * len(zs)
 
     def test_cell_count(self, simple_inputs):
+        """Cell count must equal (nx-1) * (ny-1) * (nz-1)."""
         xs, ys, zs = simple_inputs
         result = Transform.to_structured_grid(xs, ys, zs)
         expected = (len(xs) - 1) * (len(ys) - 1) * (len(zs) - 1)
@@ -70,9 +73,9 @@ class TestDepthRadiusMapping:
     """Verify that zs values map correctly to sphere radii.
 
     The proportional model is: r = radius * (1 + zs_val)
-    - zs_val = 0.0  → r = RADIUS  (on the surface)
-    - zs_val < 0.0  → r < RADIUS  (below the surface, i.e. depth)
-    - zs_val > 0.0  → r > RADIUS  (above the surface, i.e. altitude)
+    - zs_val = 0.0  -> r = RADIUS  (on the surface)
+    - zs_val < 0.0  -> r < RADIUS  (below the surface, i.e. depth)
+    - zs_val > 0.0  -> r > RADIUS  (above the surface, i.e. altitude)
     """
 
     def test_negative_zs_reduce_radius(self):
@@ -141,12 +144,14 @@ class TestDepthRadiusMapping:
         depths = np.array([0.0, -0.01, -0.05, -0.10])
         result = Transform.to_structured_grid(xs, ys, depths)
 
-        unique_radii = np.sort(np.unique(np.linalg.norm(result.points, axis=1).round(8)))
+        unique_radii = np.sort(
+            np.unique(np.linalg.norm(result.points, axis=1).round(8))
+        )
         expected = np.sort([RADIUS * (1.0 + d) for d in depths])
         np.testing.assert_allclose(unique_radii, expected, rtol=1e-5)
 
     def test_monotonically_decreasing_radii_with_depth(self):
-        """Monotonically decreasing zs must produce monotonically decreasing unique radii.
+        """Monotonically decreasing zs must produce monotonically decreasing radii.
 
         Each distinct zs value maps to a unique spherical shell; checking the
         sorted unique radii avoids any dependency on PyVista's internal point
@@ -160,7 +165,9 @@ class TestDepthRadiusMapping:
         unique_radii = np.sort(
             np.unique(np.linalg.norm(result.points, axis=1).round(8))
         )[::-1]  # largest first = surface first
-        assert len(unique_radii) == len(zs), "Each zs value must produce a distinct shell"
+        assert len(unique_radii) == len(zs), (
+            "Each zs value must produce a distinct shell"
+        )
         np.testing.assert_array_less(
             np.diff(unique_radii),
             0,
@@ -184,6 +191,7 @@ class TestToStructuredGridValidation:
         ids=["too-few-xs", "too-few-ys", "too-few-zs"],
     )
     def test_raises_on_too_few_points(self, xs, ys, zs):
+        """Fewer than 2 points in any dimension must raise ValueError."""
         with pytest.raises(ValueError, match="at least two points"):
             Transform.to_structured_grid(xs, ys, zs)
 
@@ -197,7 +205,8 @@ class TestToStructuredGridValidation:
         ids=["2d-xs", "2d-ys", "2d-zs"],
     )
     def test_raises_on_non_1d_inputs(self, xs, ys, zs):
-        with pytest.raises(ValueError, match="Require 1D"):
+        """Non-1D inputs must raise ValueError."""
+        with pytest.raises(ValueError, match="all-1D"):
             Transform.to_structured_grid(xs, ys, zs)
 
     def test_raises_on_non_wgs84_crs(self):
@@ -216,6 +225,7 @@ class TestToStructuredGridData:
     """Verify data can be attached to cells or points."""
 
     def test_attach_cell_data(self, simple_inputs):
+        """Cell-sized data is attached under NAME_CELLS."""
         xs, ys, zs = simple_inputs
         ref = Transform.to_structured_grid(xs, ys, zs)
         data = np.arange(ref.n_cells, dtype=float)
@@ -224,6 +234,7 @@ class TestToStructuredGridData:
         np.testing.assert_array_equal(result[NAME_CELLS], data)
 
     def test_attach_point_data(self, simple_inputs):
+        """Point-sized data is attached under NAME_POINTS."""
         xs, ys, zs = simple_inputs
         ref = Transform.to_structured_grid(xs, ys, zs)
         data = np.arange(ref.n_points, dtype=float)
@@ -232,6 +243,7 @@ class TestToStructuredGridData:
         np.testing.assert_array_equal(result[NAME_POINTS], data)
 
     def test_named_data(self, simple_inputs):
+        """Explicitly named data is stored under the given key."""
         xs, ys, zs = simple_inputs
         ref = Transform.to_structured_grid(xs, ys, zs)
         data = np.arange(ref.n_cells, dtype=float)

--- a/tests/bridge/test_to_structured_grid.py
+++ b/tests/bridge/test_to_structured_grid.py
@@ -20,9 +20,9 @@ from geovista.common import GV_FIELD_CRS, RADIUS
 @pytest.fixture
 def simple_inputs():
     """Minimal lon/lat/depth arrays: 4x3x3 points giving 3x2x2 cells."""
-    xs = np.linspace(-10.0, 10.0, 4)     # 4 lon points  -> 3 lon cells
-    ys = np.linspace(-5.0, 5.0, 3)       # 3 lat points  -> 2 lat cells
-    zs = np.array([0.0, -0.01, -0.02])   # 3 depth points -> 2 depth cells
+    xs = np.linspace(-10.0, 10.0, 4)  # 4 lon points  -> 3 lon cells
+    ys = np.linspace(-5.0, 5.0, 3)  # 3 lat points  -> 2 lat cells
+    zs = np.array([0.0, -0.01, -0.02])  # 3 depth points -> 2 depth cells
     return xs, ys, zs
 
 
@@ -247,9 +247,7 @@ class TestToStructuredGridData:
         xs, ys, zs = simple_inputs
         ref = Transform.to_structured_grid(xs, ys, zs)
         data = np.arange(ref.n_cells, dtype=float)
-        result = Transform.to_structured_grid(
-            xs, ys, zs, data=data, name="temperature"
-        )
+        result = Transform.to_structured_grid(xs, ys, zs, data=data, name="temperature")
         assert "temperature" in result.cell_data
 
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description

This PR is adding the ability to map a dimension of a dataset (e.g. ocean depth) to the radial distance of the globe projection. It would close #15. 

It adds a `depth` kwarg to the top level API in `Transform.from_unstructured` and adds a new method `Transform.from_structured`. I do not consider this finished but wanted to bring it up for discussion before moving on. 

It does work e.g. on the nemo example data!

```python
import pooch
import xarray as xr

import geovista as gv
from geovista.cache import CACHE

# Fetch votemper.nc through the GeoVista cache (downloads + decompresses if needed)
nc_path = CACHE.fetch(
    "pantry/data/votemper.nc.bz2",
    processor=pooch.Decompress(method="auto", name="votemper.nc"),
)

ds = xr.open_dataset(nc_path)

grid = gv.Transform.from_structured(
    ds["nav_lon"], ds["nav_lat"],
    depth=ds["deptht"],
    data=ds["votemper"].isel(time_counter=0),
    name="temperature",
    vexag=800, #vertical exaggeration to show the layers
)

# clip the output to make it easier to verify that depth is correctly modelled
grid=grid.clip(normal=(0,1,0))

contours = grid.contour([4, 6, 8, 12, 20, 30], scalars="temperature")

pl = gv.GeoPlotter()
pl.add_coastlines()
pl.add_base_layer(opacity=0.25)
pl.add_mesh(contours, scalars="temperature", cmap="viridis_r",
            opacity=1.0, clim=[4, 30])
pl.add_scalar_bar("Temperature (°C)")
pl.show()
```

https://github.com/user-attachments/assets/6bad8284-70e7-4620-804f-4a644236d9af

Very happy to change things as needed and excited to get this functionality out!

## Open questions: 
- I am unsure if a) `from_structured` is an intuitive enough name? Or should it be `from_3d`? b) if there is an opportunity to generalize `from_1d` and `from_2d` into this method. Would love to hear some thoughts on this before finishing up
- Ill have do dig a little deeper to see if this generalizes to other CRS systems. For now I have been focusing on the globe.


## TODOs
- [ ] Review tests (these are very much just Claude at this point)
- [ ] Verify that this works with unstructured data (does anyone here have a test dataset from an unstructured grid ocean/atmosphere model?)
- [ ] Review performance. There might still be inefficiencies in here that we could remove. 
    - AFAICT this depends a lot on what data models we want to support here. 1/2d lon/lat + 1d depth is a canonical one for climate data. 1/2d lon/lat + 3d depth is also common (e.g. for terrain following/hybrid vertical coordinates), but can we exclude full 3d lon/lat + 3d depth (I have never seen something like that in the wild that was structured, but happy to learn hehe). @bjlittle maybe you have some intuition about which cases should be supported.
- [ ] Write examples and docs. 



---
