### PR TITLE
docs: add `readingtime` directive

### DIFF
--- a/changelog/2307.documentation.rst
+++ b/changelog/2307.documentation.rst
@@ -1,0 +1,3 @@
+Added the custom `sphinx`_ ``readingtime`` directive to automatically estimate
+the audience reading time of a page and render a branded banner.
+(:user:`bjlittle`)

--- a/docs/src/_ext/__init__.py
+++ b/docs/src/_ext/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Sphinx extension directives."""

--- a/docs/src/_ext/readingtime.py
+++ b/docs/src/_ext/readingtime.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2021, GeoVista Contributors.
+#
+# This file is part of GeoVista and is distributed under the 3-Clause BSD license.
+# See the LICENSE file in the package root directory for licensing details.
+
+"""Sphinx extension to estimate reading time for documentation pages.
+
+Notes
+-----
+.. versionadded:: 0.6.0
+
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import re
+from typing import TYPE_CHECKING
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+WPM: int = 120
+"""Words per minute reading speed baseline for technical documentation"""
+
+
+def count_words(text: str) -> int:
+    """Count the number of words in a given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to count words in.
+
+    Returns
+    -------
+    int
+        The number of words in the text.
+
+    Notes
+    -----
+    .. versionadded:: 0.6.0
+
+    """
+    words = re.findall(r"\w+", text)
+    return len(words)
+
+
+class ReadingTimeDirective(SphinxDirective):
+    """Directive to estimate reading time for a documentation page."""
+
+    has_content = False
+    optional_arguments = 1
+    final_argument_whitespace = False
+
+    def run(self) -> list[nodes.Node]:
+        """Estimate the reading time for a documentation page.
+
+        Returns
+        -------
+        list[nodes.Node]
+            A list containing a single raw HTML node with the estimated reading time.
+
+        Notes
+        -----
+        .. versionadded:: 0.6.0
+
+        """
+        env = self.env
+        docname = env.docname
+        source_path = env.doc2path(docname)
+
+        if self.arguments:
+            try:
+                minutes = int(self.arguments[0])
+            except ValueError:
+                minutes = None
+        else:
+            minutes = None
+
+        if minutes is None:
+            with Path(source_path).open("r", encoding="utf-8") as fi:
+                text = fi.read()
+
+            # common reading speed baselines for technical docs is 100-150 wpm
+            # let's roll with the lower end to be conservative and account for
+            # code snippets, figures, etc.
+            words = count_words(text)
+            minutes = max(1, math.ceil(words / WPM))
+
+        html = (
+            f'<div class="reading-time">'
+            f'<i class="fa-solid fa-clock"></i> '
+            f"Estimated reading time: {minutes} minute{'s' if minutes != 1 else ''}"
+            f"</div>"
+        )
+
+        return [nodes.raw("", html, format="html")]
+
+
+def setup(app: Sphinx) -> None:
+    """Set up the reading time Sphinx extension.
+
+    Parameters
+    ----------
+    app : Sphinx
+        The Sphinx application object.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the extension version.
+
+    Notes
+    -----
+    .. versionadded:: 0.6.0
+
+    """
+    app.add_directive("readingtime", ReadingTimeDirective)
+    return {"version": "1.0"}

--- a/docs/src/_static/color.css
+++ b/docs/src/_static/color.css
@@ -14,6 +14,7 @@
 .fa-circle-dot,
 .fa-circle-info,
 .fa-clapperboard,
+.fa-clock,
 .fa-code,
 .fa-code-branch,
 .fa-comments,

--- a/docs/src/_static/readingtime.css
+++ b/docs/src/_static/readingtime.css
@@ -1,0 +1,10 @@
+.reading-time {
+    padding: 0.6em 1em;
+    background: var(--article-info-bg);
+    color: var(--article-info-fg);
+    border-left: 4px solid #80d050;
+    border-radius: 4px;
+    margin-bottom: 1.2em;
+    font-style: normal;
+    font-weight: bold;
+}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -36,6 +36,7 @@ import pkgutil
 import re
 import shutil
 import subprocess
+import sys
 import textwrap
 from typing import TYPE_CHECKING
 from urllib.parse import quote
@@ -74,6 +75,7 @@ if TYPE_CHECKING:
         | PythonProperty
     )
 
+sys.path.append(str(Path("_ext").absolute()))
 
 CACHE_BASE_DIR: Path = CACHE.abspath / "tests" / "docs"
 """Target directory containing documentation reference image cache"""
@@ -152,6 +154,7 @@ logger = logging.getLogger("sphinx-geovista")
 # ones.
 extensions = [
     "numpydoc",
+    "readingtime",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "autoapi.extension",
@@ -590,6 +593,7 @@ html_static_path = [
 ]
 html_css_files = [
     "color.css",
+    "readingtime.css",
     "style.css",
     "theme_overrides.css",
 ]

--- a/docs/src/developer/changelog.md
+++ b/docs/src/developer/changelog.md
@@ -1,5 +1,9 @@
 # {fa}`road-circle-check` Changelog
 
+```{eval-rst}
+.. readingtime:: 6
+```
+
 The {ref}`changelog <tippy-gv-reference-changelog>` is managed and orchestrated with
 [towncrier](https://github.com/twisted/towncrier).
 

--- a/docs/src/developer/codecraft.rst
+++ b/docs/src/developer/codecraft.rst
@@ -6,6 +6,8 @@
 :fa:`hat-wizard` Codecraft 🚧
 =============================
 
+.. readingtime::
+
 .. |pre-commit| image:: https://results.pre-commit.ci/badge/github/bjlittle/geovista/main.svg
     :target: https://results.pre-commit.ci/latest/github/bjlittle/geovista/main
 

--- a/docs/src/developer/documentation.rst
+++ b/docs/src/developer/documentation.rst
@@ -6,6 +6,8 @@
 :fa:`square-pen` Documentation
 ==============================
 
+.. readingtime::
+
 Here we provide some high-level guidelines and best practice advice for authors and
 contributors wishing to build and render the documentation.
 

--- a/docs/src/developer/packaging.rst
+++ b/docs/src/developer/packaging.rst
@@ -6,6 +6,8 @@
 :fa:`box-archive` Packaging
 ===========================
 
+.. readingtime::
+
 .. |Pixi| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json
    :target: https://pixi.prefix.dev
 .. |SPEC0| image:: https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038

--- a/docs/src/developer/testing.rst
+++ b/docs/src/developer/testing.rst
@@ -6,6 +6,8 @@
 :fa:`flask-vial` Testing
 ========================
 
+.. readingtime::
+
 .. |codecov| image:: https://codecov.io/gh/bjlittle/geovista/branch/main/graph/badge.svg?token=RVVXGP1SD3
    :target: https://codecov.io/gh/bjlittle/geovista
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -6,6 +6,8 @@
 :fa:`circle-down` Installation
 ==============================
 
+.. readingtime::
+
 :fa:`heart-circle-check` Stable
 -------------------------------
 

--- a/docs/src/next_steps.rst
+++ b/docs/src/next_steps.rst
@@ -6,6 +6,8 @@
 :fa:`seedling` Next Steps
 =========================
 
+.. readingtime::
+
 .. note::
     :class: margin, dropdown, toggle-shown
 

--- a/docs/src/overview.rst
+++ b/docs/src/overview.rst
@@ -6,6 +6,8 @@
 :fa:`panorama` Overview
 =======================
 
+.. readingtime::
+
 Here we give a high-level overview of ``geovista``.
 
 We briefly discuss its goals and motivation, and introduce you to the rich,

--- a/docs/src/quick_start.rst
+++ b/docs/src/quick_start.rst
@@ -6,6 +6,8 @@
 :fa:`truck-fast` Quick Start
 ============================
 
+.. readingtime::
+
 Now that you've :ref:`installed <tippy-gv-installation>` ``geovista``, let's take a
 quick tour to see some of the features and capabilities on offer.
 

--- a/docs/src/tutorials/region-manifold-extraction.ipynb
+++ b/docs/src/tutorials/region-manifold-extraction.ipynb
@@ -63,9 +63,8 @@
     "tags": []
    },
    "source": [
-    "```{article-info}\n",
-    ":read-time: **Tutorial ~30 minute read**\n",
-    ":class-container: sd-p-2 sd-outline-muted sd-rounded-1\n",
+    "```{eval-rst}\n",
+    ".. readingtime:: 30\n",
     "```"
    ]
   },


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Adds a custom `readingtime` directive to automatically estimate the reading time of a documentation page based on the content and a simple (conservative) technical documentation words-per-minute heuristic:

```rst
... readingtime::
```
Also accepts an optional argument of the proposed reading time (in minutes):
```rst
... readingtime:: 30
```
This is specifically necessary for `myst` parsed `markdown` to `rst`.

The directive then creates a branded reading-time banner in-situ e.g.,

<img width="632" height="248" alt="image" src="https://github.com/user-attachments/assets/ce6b4344-31b6-4250-9ec4-686c004deacc" />

----

<img width="629" height="308" alt="image" src="https://github.com/user-attachments/assets/8fe8de6b-e894-4ac2-b623-720847cee1d2" />

----

<img width="631" height="266" alt="image" src="https://github.com/user-attachments/assets/fe789c99-f2fe-472e-a01d-805e23731636" />


---
