### PR TITLE
Integration fix

### DIFF
--- a/changelog/2416.bugfix.rst
+++ b/changelog/2416.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed the ``extraction.panel_manifold`` example, which now requests a border
+width of 2 pixels. `pyvista`_ 0.49 draws a single seam shared between adjacent
+subplots rather than a border around each one, which would otherwise halve the
+width of the seam rendered between the panels.
+(:user:`larsoner`)

--- a/src/geovista/examples/extraction/panel_manifold.py
+++ b/src/geovista/examples/extraction/panel_manifold.py
@@ -78,9 +78,9 @@ def main() -> None:
 
     # Create a plotter containing three subplots in two columns, where
     # the first column has two rows, and the second column has only one.
-    # border=True keeps the outer frame, which pyvista >=0.49 otherwise
-    # drops now that it only draws the seams interior to the subplots.
-    p = gv.GeoPlotter(shape="2|1", border=True)
+    # pyvista >=0.49 draws one shared seam between subplots rather than a
+    # border per subplot, halving the seam width; ask for 2px to keep it.
+    p = gv.GeoPlotter(shape="2|1", border_width=2)
 
     # First subplot: render the sample data with a transparent
     # manifold, highlighting the manifold edges and boundary.

--- a/src/geovista/examples/extraction/panel_manifold.py
+++ b/src/geovista/examples/extraction/panel_manifold.py
@@ -78,7 +78,9 @@ def main() -> None:
 
     # Create a plotter containing three subplots in two columns, where
     # the first column has two rows, and the second column has only one.
-    p = gv.GeoPlotter(shape="2|1")
+    # border=True keeps the outer frame, which pyvista >=0.49 otherwise
+    # drops now that it only draws the seams interior to the subplots.
+    p = gv.GeoPlotter(shape="2|1", border=True)
 
     # First subplot: render the sample data with a transparent
     # manifold, highlighting the manifold edges and boundary.


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Fix for PyVista integration error due to their change in how borders are handled. Drafted with Claude Opus 5: it bisected the failure to pyvista#8494, identified that the subplot seam narrowed from 2px to 1px, and proposed the border_width=2 fix; I reviewed and verified it against both pyvista 0.49.dev0 and the pinned 0.48.4.

---
