### PR TITLE
deps: introduce max capping pin for `affine`

### DIFF
--- a/changelog/2422.dependency.rst
+++ b/changelog/2422.dependency.rst
@@ -1,0 +1,3 @@
+Introduced the temporary defensive maximum capping-pin ``affine <3.0``, an
+implicit dependency through ``rasterio``, to avoid rendering issues.
+(:user:`bjlittle`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -508,6 +508,7 @@ setuptools = ">=80.9.0,<81"
 setuptools-scm = ">=8.3.1,<9"
 
 [tool.pixi.feature.devs.dependencies]
+affine = ">=2.3.0,<3"
 check-manifest = ">=0.51.0,<0.52"
 fastparquet = ">=2024.11.0,<2027"
 h3-py = ">=4.2.2,<5"

--- a/requirements/pypi-optional-exam.txt
+++ b/requirements/pypi-optional-exam.txt
@@ -1,3 +1,4 @@
+affine <3.0
 fastparquet <2026.5.1
 h3 <4.6
 pandas <3.1


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

After investigating the failures in #2421 it appears that the recent major release of `affine` v3.0 (required by `rasterio`) is the root cause.

Introducing a temporary defensive max capping-pin until the ecosystem or `geovista` requires to adapt to the impact of this major release.

---
