### PR TITLE
fix: import `colorcet` in the `icon` examples

### DIFF
--- a/changelog/2427.bugfix.rst
+++ b/changelog/2427.bugfix.rst
@@ -1,5 +1,6 @@
-Fixed the ``unstructured.icon`` and ``unstructured.icon_eqc`` examples, which use
-the ``cet_CET_L17`` colormap but never imported ``colorcet``, and so relied on
-some other module having already registered the ``cet_*`` colormaps with
-:mod:`matplotlib`. Running either example on its own raised a ``ValueError``.
-(:user:`claude`)
+Fixed the :ref:`sphx_glr_generated_gallery_unstructured_icon.py` and
+:ref:`sphx_glr_generated_gallery_unstructured_icon_eqc.py` gallery examples,
+which use the ``cet_CET_L17`` colormap but never imported ``colorcet``, and so
+relied on some other module having already registered the ``cet_*`` colormaps
+with :mod:`matplotlib`. Running either example on its own raised a
+``ValueError``. (:user:`claude`)

--- a/changelog/2427.bugfix.rst
+++ b/changelog/2427.bugfix.rst
@@ -1,5 +1,5 @@
 Fixed the ``unstructured.icon`` and ``unstructured.icon_eqc`` examples, which use
-the ``cet_CET_L17`` colormap but never imported :mod:`colorcet`, and so relied on
+the ``cet_CET_L17`` colormap but never imported ``colorcet``, and so relied on
 some other module having already registered the ``cet_*`` colormaps with
 :mod:`matplotlib`. Running either example on its own raised a ``ValueError``.
 (:user:`claude`)

--- a/changelog/2427.bugfix.rst
+++ b/changelog/2427.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed the ``unstructured.icon`` and ``unstructured.icon_eqc`` examples, which use
+the ``cet_CET_L17`` colormap but never imported :mod:`colorcet`, and so relied on
+some other module having already registered the ``cet_*`` colormaps with
+:mod:`matplotlib`. Running either example on its own raised a ``ValueError``.
+(:user:`claude`)

--- a/src/geovista/examples/unstructured/icon.py
+++ b/src/geovista/examples/unstructured/icon.py
@@ -37,6 +37,8 @@ Note that Natural Earth coastlines are also rendered.
 
 from __future__ import annotations
 
+# required to register the "cet_*" colormaps with matplotlib
+import colorcet  # noqa: F401
 import matplotlib as mpl
 
 import geovista as gv

--- a/src/geovista/examples/unstructured/icon_eqc.py
+++ b/src/geovista/examples/unstructured/icon_eqc.py
@@ -39,6 +39,8 @@ to the Equidistant Cylindrical (Plate Carrée) conformal cylindrical projection.
 
 from __future__ import annotations
 
+# required to register the "cet_*" colormaps with matplotlib
+import colorcet  # noqa: F401
 import matplotlib as mpl
 
 import geovista as gv


### PR DESCRIPTION
## 🚀 Pull Request

### Description

`unstructured.icon` and `unstructured.icon_eqc` both build their colormap with:

```python
cmap = mpl.colormaps.get_cmap("cet_CET_L17").resampled(lutsize=9)
```

but neither module imports `colorcet`. The `cet_*` colormaps are only registered with `matplotlib` as a *side effect* of `import colorcet`, so running either example on its own fails:

```
ValueError: 'cet_CET_L17' is not a valid value for cmap.
```

Reproducer on `main`:

```bash
python -c "from geovista.examples.unstructured import icon; icon.main()"
```

#### Why the image tests never caught it

`get_modules("geovista.examples")` returns the module names *sorted*, so `grid.reykjanes_contour` always runs before `unstructured.icon`. That example passes `cmap="fire_r"` to `add_mesh`, which sends `pyvista` down its `colorcet` fallback for names it cannot resolve in `matplotlib`. That import registers the `cet_*` colormaps globally, and every example that follows silently inherits them.

So the suite only passes because of collection order. Run either `icon` test on its own and it fails.

#### Fix

Import `colorcet` explicitly in both modules. This is also better as documentation, since the examples are rendered in the gallery — a reader copying the snippet needs that import too.

### Testing

- both examples now run standalone, and `pytest "tests/plotting/test_examples.py::test[unstructured.icon]" "...[unstructured.icon_eqc]"` passes in isolation, where it previously raised
- **render neutral**, so no baseline change and no `geovista-data` release is needed. The generated images are byte identical before and after the fix (`sha256` prefix `381b0dfa2704` for `icon_eqc` in every configuration tested: pre-fix full-file run, pre-fix with `-p colorcet`, post-fix standalone, post-fix full `tests/` run, and three repeat runs)
- full `pytest tests/` — **2201 passed**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)