### PR TITLE
Ask whether anything moved, rather than how long the answer was

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -49,11 +49,22 @@ jobs:
         with:
           run-install: false
 
+      # Ask the update what moved, rather than how long the rendered summary is.
+      # `pixi-diff-to-markdown` writes "No diff" for an unchanged resolution, at 8
+      # bytes against a threshold of 10 -- a reworded "No changes" is 11, and the
+      # guard would then fail open into a weekly empty pull-request. `.environment`
+      # is empty when nothing moved and carries an entry per environment when
+      # something did.
+      #
+      # The reader runs in an assignment, not as the condition of an `if`, which is
+      # what makes `errexit` cover it: a command failing as an `if` condition is
+      # exempt, so a missing interpreter would read as "nothing moved" and pass.
       - name: "refresh pixi manifest"
         run: |
-          pixi update --json | pixi exec pixi-diff-to-markdown > diff.md
-          if [ $(wc -c < diff.md) -lt 10 ]; then
-            rm -f diff.md
+          pixi update --json > update.json
+          moved=$(python -c "import json; print(len(json.load(open('update.json'))['environment']))" < /dev/null)
+          if [ "${moved}" -gt 0 ]; then
+            pixi exec pixi-diff-to-markdown < update.json > diff.md
           fi
 
       - name: "refresh lock and yml"

--- a/changelog/2463.internal.rst
+++ b/changelog/2463.internal.rst
@@ -1,0 +1,7 @@
+The ``ci-locks`` :fab:`github` workflow decided whether ``pixi update`` had changed
+anything by measuring the length of the rendered summary, which reads ``No diff`` —
+eight bytes — when nothing has moved. Against a threshold of ten that sat two bytes
+from passing an empty update through into a weekly pull-request with nothing in it.
+It now asks ``pixi update --json`` directly, reading the answer in an assignment so
+that ``errexit`` covers a missing interpreter rather than letting it read as
+"nothing moved". (:user:`claude`)


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Ported from [bjlittle/tephpy#257](https://github.com/bjlittle/tephpy/pull/257), where the same guard was reviewed.

`ci-locks` decided whether `pixi update` had changed anything by measuring the length of the rendered summary. That guard is doing real work — I confirmed the behaviour it was added for still happens — but it should not be a byte count.

**Measured on 2026-09-02, pixi 0.76.2, both directions:**

| case | `pixi update --json` | rendered summary |
|---|---|---|
| nothing moved | `{"version": 1, "environment": {}}` | `No diff\n` — **8 bytes** |
| something moved | `environment` with **7** entries | the full table |

The threshold is `< 10`. It works, and it sits **two bytes** from not working: a reworded `No changes` is eleven, and the guard would then fail *open* — a weekly pull-request with nothing in it, which looks exactly like a working bot. Nothing would report that.

`.environment` is pixi's own answer to the same question and does not depend on how anything is worded.

### The part that needed running rather than reasoning

The obvious form puts the reader in the `if` condition. Written that way, **a missing interpreter is indistinguishable from "nothing moved"** — the command fails, the condition is false, no pull-request is opened, and the step is green.

`errexit` does not save it: a command failing as an `if` condition is exempt by definition. This was written that way first in the tephpy port, with a comment claiming `errexit` covered it; both were false, and it took running it with the interpreter renamed to find out. Verified here too — `exit 127` under `set -o errexit` only once the reader moved into an assignment.

The reader therefore runs in an **assignment**, where `SHELLOPTS: errexit:pipefail` genuinely applies. Exercised three ways against real captured JSON:

| case | outcome |
|---|---|
| no-op JSON | `moved=0` → no pull-request, step green |
| real JSON | `moved=7` → `diff.md` written → pull-request opened |
| interpreter renamed | **step fails, exit 127** — no longer silent |

`python` rather than `python3` to match the `convert lock` step in the same job, which already proves that interpreter is present.

### Checks

- `check-github-workflows` and `zizmor` pass, as does the full pre-commit run on the commit.
- No tests touched; the change is one workflow step and its changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GWt523ccqmGgGu5eEGryU
